### PR TITLE
Health check

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -9,11 +9,12 @@ from datetime import datetime
 import uvicorn
 from fastapi import FastAPI
 from src.settings import settings
-from src import cubes, dojo, experiments, runs, models, indicators
+from src import cubes, dojo, experiments, runs, models, indicators, healthcheck
 
 logger = logging.getLogger(__name__)
 
 api = FastAPI(docs_url="/")
+api.include_router(healthcheck.router, tags=['Health Check'])
 api.include_router(models.router, tags=['Models'])
 api.include_router(dojo.router, tags=['Dojo'])
 api.include_router(runs.router, tags=['Runs'])

--- a/api/src/healthcheck.py
+++ b/api/src/healthcheck.py
@@ -29,16 +29,22 @@ dmc_base_url = f"http://{dmc_url}:{dmc_port}/api/v1"
 def get_health():
 
     # DMC Status
-    url = f'{dmc_base_url}/health'
-    response = requests.get(url,auth=(dmc_user, dmc_pass))
-    dmc_status = response.json()['metadatabase']['status']
-    print(f'DMC: {dmc_status}')    
+    try:
+        url = f'{dmc_base_url}/health'
+        response = requests.get(url,auth=(dmc_user, dmc_pass))
+        dmc_status = response.json()['metadatabase']['status']
+        print(f'DMC: {dmc_status}')    
+    except:
+        dmc_status = "broken"
 
     # DOJO (actually ElasticSearch Health) Status
-    url = f'{dmc_base_url}/health'
-    dojo_status = es.cluster.health()['status']
-    print(f'Dojo: {dojo_status}') 
-
+    try:
+        url = f'{dmc_base_url}/health'
+        dojo_status = es.cluster.health()['status']
+        print(f'Dojo: {dojo_status}') 
+    except:
+        dojo_status = "broken"
+        
     status = {
              'dojo': 'ok' if dojo_status == 'yellow' or dojo_status == 'green' else "Failed Health Check",
              'dmc': 'ok' if dmc_status == 'healthy' else "Failed Health Check"

--- a/api/src/healthcheck.py
+++ b/api/src/healthcheck.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import time
+from datetime import datetime
+import requests
+from typing import Any, Dict, Generator, List, Optional
+import json
+
+from elasticsearch import Elasticsearch
+from pydantic import BaseModel, Field
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from fastapi.logger import logger
+
+from validation import IndicatorSchema
+from src.settings import settings
+
+router = APIRouter()
+
+es = Elasticsearch([settings.ELASTICSEARCH_URL], port=settings.ELASTICSEARCH_PORT)
+
+dmc_url = settings.DMC_URL
+dmc_port = settings.DMC_PORT
+dmc_user = settings.DMC_USER
+dmc_pass = settings.DMC_PASSWORD
+dmc_base_url = f"http://{dmc_url}:{dmc_port}/api/v1"
+
+@router.get("/healthcheck")
+def get_health():
+
+    # DMC Status
+    url = f'{dmc_base_url}/health'
+    response = requests.get(url,auth=(dmc_user, dmc_pass))
+    dmc_status = response.json()['metadatabase']['status']
+    print(f'DMC: {dmc_status}')    
+
+    # DOJO (actually ElasticSearch Health) Status
+    url = f'{dmc_base_url}/health'
+    dojo_status = es.cluster.health()['status']
+    print(f'Dojo: {dojo_status}') 
+
+    status = {
+             'dojo': 'ok' if dojo_status == 'yellow' or dojo_status == 'green' else "Failed Health Check",
+             'dmc': 'ok' if dmc_status == 'healthy' else "Failed Health Check"
+             }
+    return status
+
+

--- a/dmc/dags/model-xform.py
+++ b/dmc/dags/model-xform.py
@@ -18,9 +18,9 @@ import glob
 
 
 ### Get ENV variables for Causemos API
-causemos_user = os.getenv(CAUSEMOS_USER)
-causemos_pwd = os.getenv(CAUSEMOS_PWD)
-causemos_base_url = os.getenv(CAUSEMOS_BASE_URL)
+causemos_user = os.getenv('CAUSEMOS_USER')
+causemos_pwd = os.getenv('CAUSEMOS_PWD')
+causemos_base_url = os.getenv('CAUSEMOS_BASE_URL')
 
 ############################
 ####### Generate DAG #######

--- a/dmc/dags/model-xform.py
+++ b/dmc/dags/model-xform.py
@@ -16,6 +16,12 @@ from jinja2 import Template
 
 import glob
 
+
+### Get ENV variables for Causemos API
+causemos_user = os.getenv(CAUSEMOS_USER)
+causemos_pwd = os.getenv(CAUSEMOS_PWD)
+causemos_base_url = os.getenv(CAUSEMOS_BASE_URL)
+
 ############################
 ####### Generate DAG #######
 ############################
@@ -184,10 +190,10 @@ def RunExit(**kwargs):
             "job_id":run_id,
             "run_name_prefix":f"dojo_run_{model_id}_"
             }
-        response = requests.post('https://causemos.uncharted.software/api/model-run/{run_id}/post-process',
+        response = requests.post(f'{causemos_base_url}/{run_id}/post-process',
                                 headers={'Content-Type': 'application/json'}, 
                                 json=payload, 
-                                auth=('worldmodelers', 'world!')) #TODO: this auth should not be hardcoded
+                                auth=(causemos_user, causemos_pwd))
         print(f"Response from Uncharted: {response.text}")
         return
 
@@ -218,10 +224,10 @@ def post_failed_to_dojo(**kwargs):
             "job_id": run_id,
             "run_name_prefix": f"dojo_run_{model_id}_"
         }
-        response = requests.post('https://causemos.uncharted.software/api/model-run/{run_id}/run-failed',
+        response = requests.post(f'{causemos_base_url}/{run_id}/run-failed',
                                  headers={'Content-Type': 'application/json'},
                                  json=payload,
-                                 auth=('worldmodelers', 'world!'))  # TODO: this auth should not be hardcoded
+                                 auth=(causemos_user, causemos_pwd))
         print(f"Response from Uncharted: {response.text}")
         return
 

--- a/dmc/docker-compose.yaml
+++ b/dmc/docker-compose.yaml
@@ -57,6 +57,9 @@
       BUCKET_DIR: dmc_results_dev
       DMC_DEBUG: 'true'
       AIRFLOW_CONN_AWS_DEFAULT: aws://${AWS_ACCESS_KEY}:${AWS_SECRET_KEY}@
+      CAUSEMOS_BASE_URL: https://causemos.uncharted.software/api/model-run
+      CAUSEMOS_USER: worldmodelers
+      CAUSEMOS_PWD: world!
     volumes:
       - ./dags:/opt/airflow/dags
       - ./logs:/opt/airflow/logs

--- a/dmc/docker-compose.yaml
+++ b/dmc/docker-compose.yaml
@@ -51,14 +51,14 @@
       AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
       #AIRFLOW__API__ENABLE_EXPERIMENTAL_API: 'true'
       AIRFLOW__API__AUTH_BACKEND: 'airflow.api.auth.backend.basic_auth'
-      DOCKER_URL: http://192.168.1.142:8375
+      DOCKER_URL: http://10.0.0.202:8375
       DMC_LOCAL_DIR: "${PWD}"
       BUCKET: jataware-world-modelers
       BUCKET_DIR: dmc_results_dev
       DMC_DEBUG: 'true'
       AIRFLOW_CONN_AWS_DEFAULT: aws://${AWS_ACCESS_KEY}:${AWS_SECRET_KEY}@
       CAUSEMOS_BASE_URL: https://causemos.uncharted.software/api/maas/model-runs
-      CAUSEMOS_USER: worldmodelers
+      CAUSEMOS_USER: 'worldmodelers'
       CAUSEMOS_PWD: world!
     volumes:
       - ./dags:/opt/airflow/dags

--- a/dmc/docker-compose.yaml
+++ b/dmc/docker-compose.yaml
@@ -57,7 +57,7 @@
       BUCKET_DIR: dmc_results_dev
       DMC_DEBUG: 'true'
       AIRFLOW_CONN_AWS_DEFAULT: aws://${AWS_ACCESS_KEY}:${AWS_SECRET_KEY}@
-      CAUSEMOS_BASE_URL: https://causemos.uncharted.software/api/model-run
+      CAUSEMOS_BASE_URL: https://causemos.uncharted.software/api/maas/model-runs
       CAUSEMOS_USER: worldmodelers
       CAUSEMOS_PWD: world!
     volumes:

--- a/dmc/docker-compose.yaml
+++ b/dmc/docker-compose.yaml
@@ -58,7 +58,7 @@
       DMC_DEBUG: 'true'
       AIRFLOW_CONN_AWS_DEFAULT: aws://${AWS_ACCESS_KEY}:${AWS_SECRET_KEY}@
       CAUSEMOS_BASE_URL: https://causemos.uncharted.software/api/maas/model-runs
-      CAUSEMOS_USER: 'worldmodelers'
+      CAUSEMOS_USER: worldmodelers
       CAUSEMOS_PWD: world!
     volumes:
       - ./dags:/opt/airflow/dags


### PR DESCRIPTION
Issue #27 
1. Removed hard-coded causemos base url (now set in docker-compose.yaml)
2. Removed hard-coded credentials (now set in docker-compose.yaml)

Issue  #28 
3. Added /healthcheck endpoint that checks health of:
  - Dojo (verify that elasticsearch cluster is healthy), and
  - DMC (via airflow API /health endpoint)