### PR TITLE
Kimetrica Conflict and Malnutrition Models

### DIFF
--- a/models/kimetrica/conflict/conflict.json
+++ b/models/kimetrica/conflict/conflict.json
@@ -1,0 +1,94 @@
+{
+    "id": "9e896392-2639-4df6-b4b4-e1b1d4cf46ae",
+    "name": "Conflict Model",
+    "family_name": "Kimetrica",
+    "description": "This model is a continuation of the baseline conflict model that was initiated with an objective of forecasting armed conflict over time and space. In this version, we introduced the idea of peaceful days to isolate the recurrent conflict from conflicts that happen rarely. This was the major improvement made besides expanding the scope of the model from Ethiopia to the entire Horn Africa region.\n\nAs mentioned, the unique feature of this model is that it enables users to specify the number of peaceful days after a conflict. Accordingly, conflict tends to drastically drops as the number of peaceful days increase. In other words, it is possible to decrease the possibility of recurrence of conflict by increasing the number of peaceful days (0 being \"as it is or without introduction of peaceful days\", 40 being \"default\"). Notable also that the model performance declines as the number of peaceful days increases particularly beyond 90 days as conflict tends to happen very rarely which makes it difficult for the model to capture the occurrences of extremely rare events.",
+    "created_at": 1626173155060,
+    "category": [
+        "Conflict"
+    ],
+    "maintainer": {
+        "name": "Yared Hurisa",
+        "email": "yhurisalemma@air.org",
+        "organization": "Kimetrica",
+        "website": "https://gitlab.com/kimetrica/darpa/darpa/-/tree/master/models/conflict_model"
+    },
+    "image": "jataware/clouseau:claudine_ki_models",
+    "observed_data": null,
+    "is_stochastic": false,
+    "parameters": [
+        {
+            "unit": "days",
+            "default": "40",
+            "min": "0",
+            "max": "90",
+            "name": "peaceful_days",
+            "data_type": "numerical",
+            "description": "Number/duration of peaceful days after a conflict ranging from 0 to 90. 0 days means the data as it is where there is maximum number actual conflict events in a month of time. 40 peaceful days represent the default value where conflict tends to rarely happen after the threshold. As the number of peaceful days increase, the occurrence of conflict drastically drops and die-out over time.\n\nWe find that the increase in the number of days without conflict strengths societies to maintain peace particularly after certain number of days perhaps due to the increased capacity of institutions to create peace within the communities.",
+            "id": "40-11476",
+            "unit_description": "number of peaceful days",
+            "display_name": "Peaceful Days",
+            "type": "int",
+            "choices": []
+        },
+        {
+            "unit": "Percent",
+            "default": "0",
+            "min": "-1",
+            "max": "1",
+            "name": "youth_bulge_percentage_change",
+            "data_type": "numerical",
+            "description": "Proportion of youthful (15-35 years of age). The indicator increases for values between 0 and 1 and decreases between (-1 and 0) while 0 represents the actual value of the proportion of youthful population. \n\nThe assumption is that an increase in youth bulge increases the likelihood of conflict due to lack of employment and lack of resources to carry the population.",
+            "id": "0-868958",
+            "unit_description": "Percent of youth",
+            "display_name": "Youth bulge percentage change",
+            "type": "float",
+            "choices": []
+        },
+        {
+            "unit": "Percent",
+            "default": "0",
+            "min": "-1",
+            "max": "1",
+            "name": "drought_index_evaporative_stress_index",
+            "data_type": "numerical",
+            "description": "The Evaporative Stress Index (Drought Index) describes temporal anomalies in evapotranspiration (ET), highlighting areas with anomalously high or low rates of water use across the land surface. The indicator serve as a proxy for the occurrence of drought due to water shortage. \n\nThe literature indicate that drought increase the likelihood of conflict especially in farming and pastoral communities due to stress in the environment as well as lack of pasture and water.",
+            "id": "0-311316",
+            "unit_description": "Drought Index Percentage change",
+            "display_name": "Drought index (Evaporative stress index)",
+            "type": "float",
+            "choices": []
+        }
+    ],
+    "outputs": [
+        {
+            "name": "conflict_onset_forecast",
+            "display_name": "Conflict Onset Forecast",
+            "description": "Target variable for the conflict model which indicate 1, onset/presence of conflict; 0, otherwise. conflict is defined as an armed clash between two or more actors/groups such as government forces, identity groups, militias etc. the source of data is acled (the armed conflict location & event data project) collects real-time data on the locations, dates, actors, fatalities, and types of all reported political violence and protest events across many parts of the world. the variable is calculated at admin two and on monthly basis where we account a single instance of conflict as an onset regardless of the number of events occurred during one month of time. additionally, we introduced the idea of peaceful days to isolate the recurrent conflict from conflicts that happen rarely by allowing users to specify the number of peaceful days after a conflict. accordingly, conflict tends to drastically drops as the number of peaceful days increase.",
+            "type": "binary",
+            "unit": "n/a",
+            "unit_description": "n/a",
+            "is_primary": true,
+            "ontologies": {"concepts": [], "processes": [], "properties": []}
+          }        
+    ],
+    "qualifier_outputs": null,
+    "tags": null,
+    "geography": {
+        "country": [
+            "Djibouti",
+            "Ethiopia",
+            "Kenya",
+            "South Sudan",
+            "Sudan",
+            "Somalia"
+        ],
+        "admin1": null,
+        "admin2": null,
+        "admin3": null,
+        "coordinates": []
+    },
+    "period": null,
+    "type": "model",
+    "stochastic": "false"
+}

--- a/models/kimetrica/conflict/conflict.json
+++ b/models/kimetrica/conflict/conflict.json
@@ -65,7 +65,7 @@
             "name": "conflict_onset_forecast",
             "display_name": "Conflict Onset Forecast",
             "description": "Target variable for the conflict model which indicate 1, onset/presence of conflict; 0, otherwise. conflict is defined as an armed clash between two or more actors/groups such as government forces, identity groups, militias etc. the source of data is acled (the armed conflict location & event data project) collects real-time data on the locations, dates, actors, fatalities, and types of all reported political violence and protest events across many parts of the world. the variable is calculated at admin two and on monthly basis where we account a single instance of conflict as an onset regardless of the number of events occurred during one month of time. additionally, we introduced the idea of peaceful days to isolate the recurrent conflict from conflicts that happen rarely by allowing users to specify the number of peaceful days after a conflict. accordingly, conflict tends to drastically drops as the number of peaceful days increase.",
-            "type": "binary",
+            "type": "boolean",
             "unit": "n/a",
             "unit_description": "n/a",
             "is_primary": true,

--- a/models/kimetrica/conflict/conflict.py
+++ b/models/kimetrica/conflict/conflict.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# coding: utf-8
+import requests
+import json
+
+url = "http://localhost:8000"
+headers = {"Content-Type": "application/json"}
+
+#### Create Model
+payload = open("conflict.json").read()
+resp = requests.post(f"{url}/models", data=payload)
+print(resp.text)
+
+##### Add Directive
+directive = {
+    "id": "dojo/shorthand_templates/9e896392-2639-4df6-b4b4-e1b1d4cf46ae/7c4c890db081265c77b8ede2a4bbefdc.template.txt",
+    "model_id": "9e896392-2639-4df6-b4b4-e1b1d4cf46ae",
+    "command": '/bin/bash -c "set -a; source .env; luigi --module models.conflict_model.tasks models.conflict_model.tasks.Predict --peaceful-days {{ peaceful_days }} --youth-bulge {{ youth_bulge_percentage_change }} --drought-index {{ drought_index_evaporative_stress_index }} --local-scheduler"',
+}
+resp = requests.post(f"{url}/dojo/directive", json=directive)
+print(resp.text)
+
+##### Add OutputFile 1
+mapper = json.loads(open("conflict_mapper.json").read())
+# TODO: fix the path with correct one
+outputfile = {
+    "id": "conflict-outputfile-1",
+    "model_id": "9e896392-2639-4df6-b4b4-e1b1d4cf46ae",
+    "name": "conflict onset",
+    "file_type": "csv",
+    "output_directory": "/usr/src/app/output",
+    "path": "final_targets/hoa_conflict_forecast_*.csv",
+    "transform": mapper,
+}
+resp = requests.post(f"{url}/dojo/outputfile", json=[outputfile])
+print(resp.text)

--- a/models/kimetrica/conflict/conflict_mapper.json
+++ b/models/kimetrica/conflict/conflict_mapper.json
@@ -1,0 +1,50 @@
+{
+    "geo": [
+        {
+            "name": "ADMIN0",
+            "display_name": "Country",
+            "description": "country",
+            "type": "geo",
+            "geo_type": "country"
+        },
+        {
+            "name": "ADMIN1",
+            "display_name": "Admin1",
+            "description": "admin area 1",
+            "type": "geo",
+            "geo_type": "state/territory"
+        },
+        {
+            "name": "ADMIN2",
+            "display_name": "Admin2",
+            "description": "admin area 2",
+            "type": "geo",
+            "geo_type": "county/district"
+        }
+    ],
+    "date": [
+        {
+            "name": "month_year",
+            "display_name": "Month Year",
+            "description": "date",
+            "type": "date",
+            "date_type": "date",
+            "time_format": "%Y-%m",
+            "primary_date": true
+        }
+    ],
+    "feature": [
+        {
+            "name": "conflict_onset_forecast",
+            "display_name": "Conflict Onset Forecast",
+            "description": "Target variable for the conflict model which indicate 1, onset/presence of conflict; 0, otherwise. conflict is defined as an armed clash between two or more actors/groups such as government forces, identity groups, militias etc. the source of data is acled (the armed conflict location & event data project) collects real-time data on the locations, dates, actors, fatalities, and types of all reported political violence and protest events across many parts of the world. the variable is calculated at admin two and on monthly basis where we account a single instance of conflict as an onset regardless of the number of events occurred during one month of time. additionally, we introduced the idea of peaceful days to isolate the recurrent conflict from conflicts that happen rarely by allowing users to specify the number of peaceful days after a conflict. accordingly, conflict tends to drastically drops as the number of peaceful days increase.",
+            "type": "feature",
+            "feature_type": "binary",
+            "units": "n/a",
+            "units_description": ""
+        }
+    ],
+    "meta": {
+        "ftype": "csv"
+    }
+}

--- a/models/kimetrica/conflict/conflict_run.json
+++ b/models/kimetrica/conflict/conflict_run.json
@@ -1,0 +1,25 @@
+{
+    "id": "conflict-testrun-1",
+    "model_name": "Conflict Model",
+    "model_id": "9e896392-2639-4df6-b4b4-e1b1d4cf46ae",
+    "created_at": 0,
+    "data_paths": [],
+    "pre_gen_output_paths": [],
+    "is_default_run": false,
+    "tags": ["conflict"],
+    "parameters": [
+      {
+        "name": "peaceful_days",
+        "value": 40
+      },
+      {
+        "name": "youth_bulge_percentage_change",
+        "value": 0
+      },
+      {
+        "name":"drought_index_evaporative_stress_index",
+        "value": 0
+      }
+    ],
+    "attributes":{}
+  }

--- a/models/kimetrica/malnutrition/malnutrition.json
+++ b/models/kimetrica/malnutrition/malnutrition.json
@@ -1,0 +1,159 @@
+{
+    "id": "425f58a4-bbba-44d3-83f3-aba353fc7c64",
+    "name": "Malnutrition Model",
+    "family_name": "Kimetrica Models",
+    "description": "The malnutrition model was developed to predict the monthly malnutrition for Global Acute Malnutrition (GAM) and Severe Acute Malnutrition (SAM). Having these predictions enables more timely and efficient intervention efforts to reduce the prevalence of malnutrition in countries such as South Sudan and Ethiopia. According to World Health Organization (WHO) guideline, GAM and SAM are defined as weight-for-height z-score below -2, and weight-for-height z-score below -3 for children under the age of 5, respectively. Therefore, by this definition, GAM includes all categories of malnutrition.\nThe model ingests the input values and predicts the malnutrition rates of GAM and SAM for the next time point (e.g., next month) and converting that to the number of cases. Please note it does not provide forecasting based on previous values of malnutrition rates in a time series; therefore, this is not a forecast model.",
+    "created_at": 1626225277164,
+    "category": [
+        "malnutrition",
+        "food-insecurity",
+        "GAM",
+        "SAM"
+    ],
+    "maintainer": {
+        "name": "Ahmad Mohassel",
+        "email": "ahmad.mohassel@kimetrica.com",
+        "organization": "Kimetrica",
+        "website": "https://gitlab.com/kimetrica/darpa/darpa/-/tree/master/models/malnutrition_model"
+    },
+    "image": "jataware/clouseau:claudine_ki_models",
+    "observed_data": null,
+    "is_stochastic": false,
+    "parameters": [
+        {
+            "unit": "N/A",
+            "default": "2017-01-01-2017-06-01",
+            "min": null,
+            "max": null,
+            "name": "rainfall_scenario_time_range",
+            "data_type": "freeform",
+            "description": "Rainfall scenario time range in YYYY-MM-DD-YYYY-MM-DD format. \nExample: 2015-05-01-2015-05-10\nChoose a time range from 2011-06-01 to 2019-04-01",
+            "id": "2015-05-01-2015-05-10-512748",
+            "unit_description": null,
+            "display_name": "rainfall scenario time range",
+            "type": "str",
+            "choices": []
+        },
+        {
+            "unit": "N/A",
+            "default": "2017-05-01-2017-05-02",
+            "min": null,
+            "max": null,
+            "name": "time_range",
+            "data_type": "freeform",
+            "description": "time range in YYYY-MM-DD-YYYY-MM-DD format. \nExample: 2015-05-01-2015-05-10\nChoose a time range from 2011-06-01 to 2019-04-01",
+            "id": "2015-01-01-2015-06-01-310632",
+            "unit_description": null,
+            "display_name": "time range",
+            "type": "str",
+            "choices": []
+        },
+        {
+            "unit": "N/A",
+            "default": "Ethiopia",
+            "min": null,
+            "max": null,
+            "name": "country",
+            "data_type": "nominal",
+            "description": "choose the country",
+            "id": "Ethiopia-664634",
+            "unit_description": null,
+            "display_name": "country",
+            "type": "str",
+            "choices": [
+                "Ethiopia",
+                "South Sudan"
+            ]
+        },
+        {
+            "unit": "N/A",
+            "default": "ethiopia",
+            "min": null,
+            "max": null,
+            "name": "geography",
+            "data_type": "nominal",
+            "description": "choose geography",
+            "id": "ethiopia-778574",
+            "unit_description": null,
+            "display_name": "geography",
+            "type": "str",
+            "choices": [
+                "south_sudan",
+                "ethiopia"
+            ]
+        },
+        {
+            "unit": "N/A",
+            "default": "ethiopia",
+            "min": null,
+            "max": null,
+            "name": "rainfall_geography",
+            "data_type": "nominal",
+            "description": "choose rainfall geography",
+            "id": "ethiopia-744673",
+            "unit_description": null,
+            "display_name": "rainfall geography",
+            "type": "str",
+            "choices": [
+                "ethiopia",
+                "south_sudan"
+            ]
+        },
+        {
+            "unit": "N/A",
+            "default": "normal",
+            "min": null,
+            "max": null,
+            "name": "rainfall_scenario",
+            "data_type": "nominal",
+            "description": "choose rainfall scenario",
+            "id": "high-75774",
+            "unit_description": null,
+            "display_name": "rainfall scenario",
+            "type": "str",
+            "choices": [
+                "low",
+                "high",
+                "mean",
+                "normal"
+            ]
+        }
+    ],
+    "outputs": [
+        {
+            "name": "gam_rate",
+            "display_name": "Gam Rate",
+            "description": "global acute malnutrition (gam) ",
+            "type": "float",
+            "unit": "n/a",
+            "unit_description": "",
+            "is_primary": true,
+            "ontologies": {"concepts": [], "processes": [], "properties": []}            
+        },
+        {
+            "name": "sam_rate",
+            "display_name": "Sam Rate",
+            "description": "severe acute malnutrition (sam)",
+            "type": "float",
+            "unit": "n/a",
+            "unit_description": "",
+            "is_primary": true,
+            "ontologies": {"concepts": [], "processes": [], "properties": []} 
+        }
+    ],
+    "qualifier_outputs": null,
+    "tags": null,
+    "geography": {
+        "country": [
+            "Ethiopia",
+            "South Sudan"
+        ],
+        "admin1": null,
+        "admin2": null,
+        "admin3": null,
+        "coordinates": []
+    },
+    "period": null,
+    "type": "model",
+    "stochastic": "false"
+}

--- a/models/kimetrica/malnutrition/malnutrition.py
+++ b/models/kimetrica/malnutrition/malnutrition.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# coding: utf-8
+import requests
+import json
+
+url = "http://localhost:8000"
+headers = {"Content-Type": "application/json"}
+
+#### Create Model
+payload = open("malnutrition.json").read()
+resp = requests.post(f"{url}/models", data=payload)
+print(resp.text)
+
+##### Add Directive
+directive = {
+    "id": "dojo/shorthand_templates/425f58a4-bbba-44d3-83f3-aba353fc7c64/73d98cd3ecf0a0a0013780f369b3d297.template.txt",
+    "model_id": "425f58a4-bbba-44d3-83f3-aba353fc7c64",
+    "command": '/bin/bash -c "set -a; source .env; luigi --module models.malnutrition_model.tasks models.malnutrition_model.tasks.MalnutInference --time {{ time_range }} --rainfall-scenario-time {{ rainfall_scenario_time_range }} --country-level {{ country }} --geography /usr/src/app/models/geography/boundaries/{{ geography }}_2d.geojson --rainfall-scenario-geography /usr/src/app/models/geography/boundaries/{{ rainfall_geography }}_2d.geojson --rainfall-scenario {{ rainfall_scenario }} --local-scheduler"'
+  }
+resp = requests.post(f"{url}/dojo/directive", json=directive)
+print(resp.text)
+
+##### Add OutputFile 1
+mapper = json.loads(open("malnutrition_mapper.json").read())
+outputfile = {
+    "id": "malnutrition-outputfile-1",
+    "model_id": "425f58a4-bbba-44d3-83f3-aba353fc7c64",
+    "name": "malnutrition",
+    "file_type": "csv",
+    "output_directory": "/usr/src/app/output",
+    "path": "final_targets/maln_inference_*.csv",
+    "transform": mapper,
+}
+resp = requests.post(f"{url}/dojo/outputfile", json=[outputfile])
+print(resp.text)

--- a/models/kimetrica/malnutrition/malnutrition_mapper.json
+++ b/models/kimetrica/malnutrition/malnutrition_mapper.json
@@ -1,0 +1,72 @@
+{
+    "geo": [
+        {
+            "name": "County",
+            "display_name": "County",
+            "description": "county",
+            "type": "geo",
+            "geo_type": "municipality/town"
+        },
+        {
+            "name": "admin2",
+            "display_name": "Admin2",
+            "description": "admin area 2",
+            "type": "geo",
+            "geo_type": "county/district"
+        },
+        {
+            "name": "admin1",
+            "display_name": "Admin1",
+            "description": "admin area 1",
+            "type": "geo",
+            "geo_type": "state/territory"
+        }
+    ],
+    "date": [
+        {
+            "name": "Time",
+            "display_name": "Time",
+            "description": "date",
+            "type": "date",
+            "date_type": "date",
+            "time_format": "%Y-%m-%dT%H:%M:%S",
+            "primary_date": true
+        }
+    ],
+    "feature": [
+        {
+            "name": "gam_rate",
+            "display_name": "Gam Rate",
+            "description": "global acute malnutrition (gam) ",
+            "type": "feature",
+            "feature_type": "float",
+            "units": "n/a",
+            "units_description": ""
+        },
+        {
+            "name": "sam_rate",
+            "display_name": "Sam Rate",
+            "description": "severe acute malnutrition (sam)",
+            "type": "feature",
+            "feature_type": "float",
+            "units": "n/a",
+            "units_description": ""
+        },
+        {
+            "name": "rainfall_scenario",
+            "display_name": "Rainfall Scenario",
+            "description": "rainfall scenario",
+            "type": "feature",
+            "feature_type": "string",
+            "units": "n/a",
+            "units_description": "",
+            "qualifies": [
+                "gam_rate",
+                "sam_rate"
+            ]
+        }
+    ],
+    "meta": {
+        "ftype": "csv"
+    }
+}

--- a/models/kimetrica/malnutrition/malnutrition_run.json
+++ b/models/kimetrica/malnutrition/malnutrition_run.json
@@ -1,0 +1,37 @@
+{
+    "id": "malnutrition-testrun-1",
+    "model_name": "Malnutrition Model",
+    "model_id": "425f58a4-bbba-44d3-83f3-aba353fc7c64",
+    "created_at": 0,
+    "data_paths": [],
+    "pre_gen_output_paths": [],
+    "is_default_run": false,
+    "tags": ["health"],
+    "parameters": [
+      {
+        "name": "rainfall_scenario_time_range",
+        "value": "2017-01-01-2017-06-01"
+      },
+      {
+        "name": "time_range",
+        "value": "2017-05-01-2017-05-02"
+      },
+      {
+        "name":"country",
+        "value": "Ethiopia"
+      },
+      {
+        "name":"geography",
+        "value": "ethiopia"
+      },
+      {
+        "name":"rainfall_geography",
+        "value": "ethiopia"
+      },
+      {
+        "name":"rainfall_scenario",
+        "value": "normal"
+      }
+    ],
+    "attributes":{}
+  }


### PR DESCRIPTION
## Overview

This PR adds the Kimetrica Conflict and Malnutrition models.

## How to test

Assuming you have Dojo and DMC up and running, you may add either of these models by navigating to their directory in `models/kimetrica/` and running `conflict.py` or `malnutrition.py`. 

You should then send the example run (`conflict_run.json` or malnutrition_run.json`) to the `/runs` endpoint.

## Issues

One thing to note: the Spacetag mapper files were generated by me; the one for the malnutrition model is likely quite incorrect. Ahmad is going to register that model's output in Spacetag so we can get a working mapper. The conflict model has a simple description for it's binary output and the description was provided by Yared already.