### PR TITLE
Add Google Trends 

### DIFF
--- a/models/googletrends/Dockerfile
+++ b/models/googletrends/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.8
+
+WORKDIR /
+
+COPY requirements.txt .
+
+RUN pip install -r requirements.txt
+
+COPY / .
+
+ENTRYPOINT ["python3","./trends.py"]

--- a/models/googletrends/README.md
+++ b/models/googletrends/README.md
@@ -13,16 +13,16 @@ Then run Dojo/DMC as you normally would.
 
 Next run:
 
-'''
-cd api/es-mappings
-python3 CreateMappings.py
-'''
+    cd api/es-mappings
+    python3 CreateMappings.py
 
 Then,
 
-'''
-cd ~models/googletrends
-python3 google_trends.py
-'''
+    cd ~models/googletrends
+    python3 google_trends.py
 
+
+At: `http://localhost:8000/#/Runs/create_run_runs_post`: 
 Submit a model run `google_trends_run.json` with desired search term and geographic area(s) reflected in the `parameters` dictionary.
+
+Inspect the DAG at `http://localhost:8080/` to monitor model run progress.

--- a/models/googletrends/README.md
+++ b/models/googletrends/README.md
@@ -4,25 +4,23 @@ Details on the Google Trends Model can be found [here](https://github.com/jatawa
 
 ## Running Google Trends in Dojo
 
-Follow all instructions for running Dojo and DMC. Prior to running Dojo, there are two changes that must occur manually to avoid conflicting Redis port usage.
+Update the following:
 
-- api/src/settings.py: change REDIS_PORT to 6380
-- api/docker-compose.yaml: change line 47 to 6380:6379
-- Delete any lingering or old Elasticsearch volumes associated with Dojo API (unless they have something you wish to save--in that case back them up).
-Then run Dojo/DMC as you normally would.
-
-Next run:
-
-    cd api/es-mappings
-    python3 CreateMappings.py
-
-Then,
-
-    cd ~models/googletrends
-    python3 google_trends.py
+- `api/src/settings.py`: change REDIS_PORT to 6380
+- `api/docker-compose.yaml`: change line 47 to 6380:6379
+- Delete Elasticsearch volumes associated with Dojo API (save anything you may need/want)
+- Run:
 
 
-At: `http://localhost:8000/#/Runs/create_run_runs_post`: 
-Submit a model run `google_trends_run.json` with desired search term and geographic area(s) reflected in the `parameters` dictionary.
+      cd api/es-mappings
+      python3 CreateMappings.py
 
-Inspect the DAG at `http://localhost:8080/` to monitor model run progress.
+- Then, create the google_trends model with:
+
+      cd ~models/googletrends
+      python3 google_trends.py
+
+- Go to: `http://localhost:8000/#/Runs/create_run_runs_post` to submit a model run:
+   - `google_trends_run.json` is an example; you may use it as is or change the desired search term and geographic area(s) reflected in the `parameters` dictionary. Update the `model_id` for subsequent runs.
+
+- Inspect the DAG at `http://localhost:8080/` to monitor model run progress.

--- a/models/googletrends/README.md
+++ b/models/googletrends/README.md
@@ -1,0 +1,24 @@
+# Google Trends Model
+
+Details on the Google Trends Model can be found [here](https://github.com/jataware/open-indicators/tree/master/google-trends).
+
+## Running Google Trends in Dojo
+
+Follow all instructions for running Dojo and DMC. Prior to running Dojo, there are two changes that must occur manually to avoid conflicting Redis port usage.
+
+- api/src/settings.py: change REDIS_PORT to 6380
+- api/docker-compose.yaml: change line 47 to 6380:6379
+- Delete any lingering or old Elasticsearch volumes associated with Dojo API (unless they have something you wish to save--in that case back them up).
+Then run Dojo/DMC as you normally would.
+
+Next run:
+
+cd api/es-mappings
+python3 CreateMappings.py
+
+Then,
+
+cd ~models/googletrends
+python3 google_trends.py
+
+Submit a model run `google_trends_run.json` with desired search term and geographic area(s) reflected in the `parameters` dictionary.

--- a/models/googletrends/README.md
+++ b/models/googletrends/README.md
@@ -13,12 +13,16 @@ Then run Dojo/DMC as you normally would.
 
 Next run:
 
+'''
 cd api/es-mappings
 python3 CreateMappings.py
+'''
 
 Then,
 
+'''
 cd ~models/googletrends
 python3 google_trends.py
+'''
 
 Submit a model run `google_trends_run.json` with desired search term and geographic area(s) reflected in the `parameters` dictionary.

--- a/models/googletrends/google_trends.json
+++ b/models/googletrends/google_trends.json
@@ -38,7 +38,7 @@
     {
       "name": "country",
       "display_name": "Country",
-      "description": "The country of interest to return the trend data. The spelling and formatting must match the reference iso-codes.csv file found at: https://github.com/jataware/open-indicators/blob/master/google-trends/iso-codes.csv",
+      "description": "The country of interest to return the trend data. The spelling and formatting must match the reference country_admin1.csv file found at: https://github.com/jataware/open-indicators/blob/master/google-trends/country_admin1.csv",
       "type": "str",
       "unit": "n/a",
       "unit_description": null,
@@ -53,9 +53,9 @@
       "id": "UnitedStatesofAmerica-300669"
     },
     {
-      "name": "admin",
-      "display_name": "admin1",
-      "description": "The admin1/state/territory of interest to return the trend data; must be part of the country/admin0 selected for country. The spelling and formatting must match the reference iso-codes.csv file found at: https://github.com/jataware/open-indicators/blob/master/google-trends/iso-codes.csv",
+      "name": "admin1",
+      "display_name": "admin area level 1",
+      "description": "The admin1/state/territory of interest to return the trend data; must be part of the country/admin0 selected for country. The spelling and formatting must match the reference country_admin1.csv file found at: https://github.com/jataware/open-indicators/blob/master/google-trends/country_admin1.csv",
       "type": "str",
       "unit": "n/a",
       "unit_description": null,

--- a/models/googletrends/google_trends.json
+++ b/models/googletrends/google_trends.json
@@ -14,7 +14,7 @@
     "organization": "Jataware",
     "website": "https://github.com/jataware/open-indicators/blob/master/google-trends/"
   },
-  "image": "jataware/dojo-publish:GoogleTrends-latest",
+  "image": "redbeard14/google_trends",
   "observed_data": null,
   "is_stochastic": false,
   "parameters": [
@@ -78,10 +78,24 @@
         "type": "int",
         "unit": "n/a",
         "unit_description": "",
-        "is_primary": true
+        "is_primary": true,
+        "ontologies": {"concepts": [],"processes": [],"properties": []}
     }
   ],
-  "qualifier_outputs": null,
+  "qualifier_outputs":[ 
+    {
+        "name": "description",
+        "display_name": "Description",
+        "description": "label of the keyword and geography selected.",
+        "type": "str",
+        "unit": "n/a",
+        "unit_description": "",
+        "related_features": [
+            "value"
+        ],
+        "ontologies": {"concepts": [],"processes": [],"properties": []}
+    }
+  ],
   "tags": null,
   "geography": {
     "country": null,

--- a/models/googletrends/google_trends.json
+++ b/models/googletrends/google_trends.json
@@ -1,0 +1,96 @@
+{
+  "id": "ca83b434-0f6a-4375-874c-bed9032bf779",
+  "name": "Google Trends",
+  "family_name": "Jataware",
+  "description": "Google Trends searches for keywords and returns trend data for a specified geographic area. The trend data is derived from the popularity of search queries from the Google search engine.",
+  "created_at": 1626309077629,
+  "category": [
+    "trends",
+    "google_search"
+  ],
+  "maintainer": {
+    "name": "Brandon Rose",
+    "email": "brandon@jataware.com",
+    "organization": "Jataware",
+    "website": "https://github.com/jataware/open-indicators/blob/master/google-trends/"
+  },
+  "image": "jataware/dojo-publish:GoogleTrends-latest",
+  "observed_data": null,
+  "is_stochastic": false,
+  "parameters": [
+    {
+      "name": "search_term",
+      "display_name": "search term",
+      "description": "The search term or keyword of interest for obtaining a historical google search trend. Think of the search term the same as a search term with Google.",
+      "type": "str",
+      "unit": "n/a",
+      "unit_description": null,
+      "ontologies": null,
+      "is_drilldown": null,
+      "additional_options": null,
+      "data_type": "freeform",
+      "default": "world modelers",
+      "choices": [],
+      "min": null,
+      "max": null,
+      "id": "soccergame-660167"
+    },
+    {
+      "name": "country",
+      "display_name": "Country",
+      "description": "The country of interest to return the trend data. \n\nThe spelling and formatting must match the reference iso-codes.csv file found at: https://github.com/jataware/open-indicators/blob/master/google-trends/iso-codes.csv",
+      "type": "str",
+      "unit": "n/a",
+      "unit_description": null,
+      "ontologies": null,
+      "is_drilldown": null,
+      "additional_options": null,
+      "data_type": "freeform",
+      "default": "United States of America",
+      "choices": [],
+      "min": null,
+      "max": null,
+      "id": "UnitedStatesofAmerica-300669"
+    },
+    {
+      "name": "admin",
+      "display_name": "admin1",
+      "description": "The admin1/state/territory of interest to return the trend data; must be part of the country/admin0 selected for country.\n\nThe spelling and formatting must match the reference iso-codes.csv file found ​at: https://github.com/jataware/open-indicators/blob/master/google-trends/iso-codes.csv",
+      "type": "str",
+      "unit": "n/a",
+      "unit_description": null,
+      "ontologies": null,
+      "is_drilldown": null,
+      "additional_options": null,
+      "data_type": "freeform",
+      "default": "Virginia",
+      "choices": [],
+      "min": null,
+      "max": null,
+      "id": "Oregon-805706"
+    }
+  ],
+  "outputs": [
+    {
+        "name": "value",
+        "display_name": "value",
+        "description": "A normalized score on how 'popular' your keyword is for your chosen geopolitical area versus other searches at a particular time.",
+        "type": "int",
+        "unit": "n/a",
+        "unit_description": "",
+        "is_primary": true
+    }
+  ],
+  "qualifier_outputs": null,
+  "tags": null,
+  "geography": {
+    "country": null,
+    "admin1": null,
+    "admin2": null,
+    "admin3": null,
+    "coordinates": []
+  },
+  "period": null,
+  "type": "model",
+  "stochastic": "false"
+}

--- a/models/googletrends/google_trends.json
+++ b/models/googletrends/google_trends.json
@@ -38,7 +38,7 @@
     {
       "name": "country",
       "display_name": "Country",
-      "description": "The country of interest to return the trend data. \n\nThe spelling and formatting must match the reference iso-codes.csv file found at: https://github.com/jataware/open-indicators/blob/master/google-trends/iso-codes.csv",
+      "description": "The country of interest to return the trend data. The spelling and formatting must match the reference iso-codes.csv file found at: https://github.com/jataware/open-indicators/blob/master/google-trends/iso-codes.csv",
       "type": "str",
       "unit": "n/a",
       "unit_description": null,
@@ -55,7 +55,7 @@
     {
       "name": "admin",
       "display_name": "admin1",
-      "description": "The admin1/state/territory of interest to return the trend data; must be part of the country/admin0 selected for country.\n\nThe spelling and formatting must match the reference iso-codes.csv file found ​at: https://github.com/jataware/open-indicators/blob/master/google-trends/iso-codes.csv",
+      "description": "The admin1/state/territory of interest to return the trend data; must be part of the country/admin0 selected for country. The spelling and formatting must match the reference iso-codes.csv file found at: https://github.com/jataware/open-indicators/blob/master/google-trends/iso-codes.csv",
       "type": "str",
       "unit": "n/a",
       "unit_description": null,

--- a/models/googletrends/google_trends.py
+++ b/models/googletrends/google_trends.py
@@ -15,7 +15,7 @@ print(resp.text)
 directive = {
   "id": "dojo/shorthand_templates/ca83b434-0f6a-4375-874c-bed9032bf779/f07f739babe071f4ef8c250865d6194c.template.txt",
   "model_id": "ca83b434-0f6a-4375-874c-bed9032bf779",
-  "command": "python3 trends.py --term=\"{{ search_term }}\" --country=\"{{ country }}\" --state=\"{{ admin }}\" --output=output/output.csv",
+  "command": "docker run redbeard14/google_trends --term=\"{{ search_term }}\" --country=\"{{ country }}\" --state=\"{{ admin }}\" --output=output/output.csv",
   "output_directory": "/output"
 }
 resp = requests.post(f"{url}/dojo/directive", json=directive)
@@ -28,7 +28,7 @@ outputfile = {
     "model_id": "ca83b434-0f6a-4375-874c-bed9032bf779",
     "name": "google_trends",
     "file_type": "csv",
-    "output_directory": "/",
+    "output_directory": "/outputfile",
     "path": "output.csv",
     "transform": mapper,
 }

--- a/models/googletrends/google_trends.py
+++ b/models/googletrends/google_trends.py
@@ -15,8 +15,7 @@ print(resp.text)
 directive = {
   "id": "dojo/shorthand_templates/ca83b434-0f6a-4375-874c-bed9032bf779/f07f739babe071f4ef8c250865d6194c.template.txt",
   "model_id": "ca83b434-0f6a-4375-874c-bed9032bf779",
-  "command": "docker run redbeard14/google_trends --term=\"{{ search_term }}\" --country=\"{{ country }}\" --state=\"{{ admin }}\" --output=output/output.csv",
-  "output_directory": "/output"
+  "command": "--term='{{ search_term }}' --country='{{ country }}' --state='{{ admin }}' --output=output/output.csv"
 }
 resp = requests.post(f"{url}/dojo/directive", json=directive)
 print(resp.text)
@@ -28,7 +27,7 @@ outputfile = {
     "model_id": "ca83b434-0f6a-4375-874c-bed9032bf779",
     "name": "google_trends",
     "file_type": "csv",
-    "output_directory": "/outputfile",
+    "output_directory": "/output",
     "path": "output.csv",
     "transform": mapper,
 }

--- a/models/googletrends/google_trends.py
+++ b/models/googletrends/google_trends.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# coding: utf-8
+import requests
+import json
+
+url = "http://localhost:8000"
+headers = {"Content-Type": "application/json"}
+
+#### Create Model
+payload = open("google_trends.json").read()
+resp = requests.post(f"{url}/models", data=payload)
+print(resp.text)
+
+##### Add Directive
+directive = {
+  "id": "dojo/shorthand_templates/ca83b434-0f6a-4375-874c-bed9032bf779/f07f739babe071f4ef8c250865d6194c.template.txt",
+  "model_id": "ca83b434-0f6a-4375-874c-bed9032bf779",
+  "command": "python3 trends.py --term=\"{{ search_term }}\" --country=\"{{ country }}\" --state=\"{{ admin }}\" --output=output/output.csv",
+  "output_directory": "/output"
+}
+resp = requests.post(f"{url}/dojo/directive", json=directive)
+print(resp.text)
+
+##### Add OutputFile 1
+mapper = json.loads(open("google_trends_mapper.json").read())
+outputfile = {
+    "id": "google_trends-outputfile-1",
+    "model_id": "ca83b434-0f6a-4375-874c-bed9032bf779",
+    "name": "google_trends",
+    "file_type": "csv",
+    "output_directory": "/",
+    "path": "output.csv",
+    "transform": mapper,
+}
+resp = requests.post(f"{url}/dojo/outputfile", json=[outputfile])
+print(resp.text)

--- a/models/googletrends/google_trends.py
+++ b/models/googletrends/google_trends.py
@@ -15,7 +15,7 @@ print(resp.text)
 directive = {
   "id": "dojo/shorthand_templates/ca83b434-0f6a-4375-874c-bed9032bf779/f07f739babe071f4ef8c250865d6194c.template.txt",
   "model_id": "ca83b434-0f6a-4375-874c-bed9032bf779",
-  "command": "--term='{{ search_term }}' --country='{{ country }}' --state='{{ admin }}' --output=output/output.csv"
+  "command": "--term='{{ search_term }}' --country='{{ country }}' --state='{{ admin1 }}' --output=output/output.csv"
 }
 resp = requests.post(f"{url}/dojo/directive", json=directive)
 print(resp.text)

--- a/models/googletrends/google_trends_mapper.json
+++ b/models/googletrends/google_trends_mapper.json
@@ -1,0 +1,62 @@
+{
+    "geo":
+    [
+        {
+            "name": "country",
+            "display_name": "country",
+            "description": "country selected for keyword trend analysis.",
+            "type": "country",
+            "geo_type": "country",
+            "primary_geo": true
+        },
+        {
+            "name": "state",
+            "display_name": "state",
+            "description": "state/admin1 selected for keyword trend analysis.",
+            "type": "admin1",
+            "geo_type": "country",
+            "primary_geo": false
+        }
+
+    ],
+    "date":
+    [
+        {
+            "name": "timestamp",
+            "display_name": "timestamp",
+            "description": "Date of google trends data in epoch time (seconds)",
+            "type": "date",
+            "date_type": "epoch",
+            "primary_date": true
+        }
+    ],
+    "feature":
+    [
+        {
+            "name": "value",
+            "display_name": "Value",
+            "description": "a normalized score on how 'popular' your keyword is for your chosen geopolitical area versus other searches at a particular time.",
+            "type": "feature",
+            "feature_type": "int",
+            "units": "n/a",
+            "units_description": ""
+        },
+        {
+            "name": "description",
+            "display_name": "Description",
+            "description": "label of the keyword and geography selected.",
+            "type": "feature",
+            "feature_type": "string",
+            "units": "n/a",
+            "units_description": "",
+            "qualifies":
+            [
+                "value"
+            ]
+        }
+    ],
+    "meta":
+    {
+        "ftype": "csv"
+    }
+}

--- a/models/googletrends/google_trends_run.json
+++ b/models/googletrends/google_trends_run.json
@@ -1,0 +1,25 @@
+{
+    "id": "google_trends",
+    "model_name": "Google Trends",
+    "model_id": "ca83b434-0f6a-4375-874c-bed9032bf779",
+    "created_at": 0,
+    "data_paths": [],
+    "pre_gen_output_paths": [],
+    "is_default_run": false,
+    "tags": [],
+    "parameters": [
+      {
+        "name": "search_term",
+        "value": "teff"
+      },
+      {
+        "name":"country",
+        "value": "Ethiopia"
+      },
+      {
+        "name":"admin",
+        "value": "Oromia Region"
+      }
+    ],
+    "attributes":{}
+  }


### PR DESCRIPTION
What's New: Google Trends model that can be executed in DMC.

How to test the PR
- Checkout the `google_trends` branch. 
- Go to the [README](https://github.com/jataware/dojo/tree/google_trends/models/googletrends) for spin-up instructions and   testing.

Known Issue:
A successful model run will not include a push to S3; but all other nodes prior should be green in Airflow.
