### PR TITLE
Send models to UAZ

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -8,4 +8,4 @@ DMC_PASSWORD=wileyhippo
 DOJO_URL=http://SET_DOJO_URL_HERE:8000
 DMC_LOCAL_DIR=/path_to/dojo/dmc
 REDIS_HOST=redis1
-UAZ_URL=http://linking.cs.arizona.edu/v1/groundIndicator?maxHits=10&threshold=0.7&compositional=true
+UAZ_URL=http://linking.cs.arizona.edu/v1

--- a/api/.env
+++ b/api/.env
@@ -9,3 +9,5 @@ DOJO_URL=http://SET_DOJO_URL_HERE:8000
 DMC_LOCAL_DIR=/path_to/dojo/dmc
 REDIS_HOST=redis1
 UAZ_URL=http://linking.cs.arizona.edu/v1
+UAZ_THRESHOLD=0.6
+UAZ_HITS=10

--- a/api/logging.yaml
+++ b/api/logging.yaml
@@ -25,12 +25,12 @@ handlers:
 
 loggers:
   "":
-    level: DEBUG
+    level: INFO
     handlers:
       - console
     propagate: False
   fastapi:
-    level: DEBUG
+    level: INFO
     handlers:
       - console
     propagate: False

--- a/api/src/indicators.py
+++ b/api/src/indicators.py
@@ -38,9 +38,10 @@ def create_indicator(payload: IndicatorSchema.IndicatorMetadataSchema):
     body = payload.json()
     data = json.loads(body)
 
-    # UAZ API Does not return ontologies for "qualifier_outputs" so work on just "outputs" for now
+    # TODO: UAZ API Does not return ontologies for "qualifier_outputs" so work on just "outputs" for now
     try:
         ontology_dict = get_ontology(data, type="indicator")
+        logger.info(f"Sent indicator to UAZ")
         for output in data["outputs"]:
             output["ontologies"] = ontology_dict[output["name"]]
 

--- a/api/src/indicators.py
+++ b/api/src/indicators.py
@@ -19,6 +19,7 @@ from validation import IndicatorSchema, DojoSchema
 from src.settings import settings
 
 from src.dojo import search_and_scroll
+from src.ontologies import get_ontology
 import os
 
 router = APIRouter()
@@ -30,39 +31,6 @@ def current_milli_time():
     return round(time.time() * 1000)
 
 
-def get_ontology(data):
-    headers = {"accept": "application/json", "Content-Type": "application/json"}
-    url = os.getenv("UAZ_URL")
-
-    try:
-        logger.debug(f"Sending indicator to {url}")
-        response = requests.put(url, json=data, headers=headers)
-        logger.debug(f"response: {response}")
-        logger.debug(f"response reason: {response.raw.reason}")
-
-        # Ensure good response and not an empty response
-        if response.status_code == 200:
-            resp_str = response.content.decode("utf8")
-            ontologies = json.loads(resp_str)
-
-            # Capture UAZ ontology data
-            ontology_dict = {}
-            for ontology in ontologies["outputs"]:
-                key = ontology["name"]
-                datuh = ontology["ontologies"]
-                ontology_dict[key] = datuh
-
-            return ontology_dict
-
-        else:
-            logger.debug(f"else response: {response}")
-            return response
-
-    except Exception as e:
-        logger.error(f"Encountered problems communicating with UAZ service: {e}")
-        logger.exception(e)
-
-
 @router.post("/indicators")
 def create_indicator(payload: IndicatorSchema.IndicatorMetadataSchema):
     indicator_id = payload.id
@@ -72,7 +40,7 @@ def create_indicator(payload: IndicatorSchema.IndicatorMetadataSchema):
 
     # UAZ API Does not return ontologies for "qualifier_outputs" so work on just "outputs" for now
     try:
-        ontology_dict = get_ontology(data)
+        ontology_dict = get_ontology(data, type="indicator")
         for output in data["outputs"]:
             output["ontologies"] = ontology_dict[output["name"]]
 

--- a/api/src/models.py
+++ b/api/src/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 from datetime import datetime
+import json
 from typing import Any, Dict, Generator, List, Optional
 
 from elasticsearch import Elasticsearch
@@ -13,6 +14,7 @@ from validation import ModelSchema, DojoSchema
 
 from src.settings import settings
 from src.dojo import search_and_scroll
+from src.ontologies import get_ontology
 
 router = APIRouter()
 
@@ -24,12 +26,35 @@ def current_milli_time():
     return round(time.time() * 1000)
 
 
+def update_ontologies(model):
+    '''
+    This is a function cribbed from indicators.py to send data to UAZ
+    Here we send a dictionary of a model to UAZ
+    It is returned with the outputs ontology-mapped
+    '''
+    # TODO: UAZ API Does not return ontologies for "qualifier_outputs" so work on just "outputs" for now
+    try:
+        model = json.loads(model)
+        ontology_dict = get_ontology(model, type="model")
+        logger.info(ontology_dict)
+        for output in model["outputs"]:
+            output["ontologies"] = ontology_dict[output["name"]]
+        logger.debug(f"Model with UAZ: {model}")
+        return model
+
+    except Exception as e:
+        logger.error(f"Failed to generate ontologies for model: {str(e)}")
+        logger.exception(e)
+        return model
+
+
 @router.post("/models")
 def create_model(payload: ModelSchema.ModelMetadataSchema):
     model_id = payload.id
     payload.created_at = current_milli_time()
     body = payload.json()
-    es.index(index="models", body=body, id=model_id)
+    model = update_ontologies(body)
+    es.index(index="models", body=model, id=model_id)
     return Response(
         status_code=status.HTTP_201_CREATED,
         headers={"location": f"/api/models/{model_id}"},
@@ -51,7 +76,8 @@ def update_model(model_id: str, payload: ModelSchema.ModelMetadataSchema):
 
 @router.patch("/models/{model_id}")
 def modify_model(model_id: str, payload: dict = Body(...)):
-    es.update(index="models", body={"doc": payload}, id=model_id)
+    model = update_ontologies(payload)
+    es.update(index="models", body={"doc": model}, id=model_id)
     return Response(
         status_code=status.HTTP_200_OK,
         headers={"location": f"/api/models/{model_id}"},

--- a/api/src/ontologies.py
+++ b/api/src/ontologies.py
@@ -1,0 +1,54 @@
+import requests
+import json
+import os
+from fastapi.logger import logger
+
+def get_ontology(data, type="indicator"):
+    """
+    A function to submit either indicators or models to the UAZ 
+    ontology mapping service
+
+    Params:
+        - data: the indicator or model object
+        - type: one of either [indicator, model]
+    """
+    headers = {"accept": "application/json", "Content-Type": "application/json"}
+    url = os.getenv("UAZ_URL")
+    params = "?maxHits=10&threshold=0.7&compositional=true"
+
+    # Send to either /groundIndicator or /groundModel
+    if type == "indicator":
+        type_ = "groundIndicator"
+    elif type == "model":
+        type_ = "groundModel"
+    
+    # Build final URL to route to UAZ
+    url_ = f"{url}/{type_}/{params}"
+
+    try:
+        logger.debug(f"Sending data to {url}")
+        response = requests.put(url_, json=data, headers=headers)
+        logger.debug(f"response: {response}")
+        logger.debug(f"response reason: {response.raw.reason}")
+
+        # Ensure good response and not an empty response
+        if response.status_code == 200:
+            resp_str = response.content.decode("utf8")
+            ontologies = json.loads(resp_str)
+
+            # Capture UAZ ontology data
+            ontology_dict = {}
+            for ontology in ontologies["outputs"]:
+                key = ontology["name"]
+                datuh = ontology["ontologies"]
+                ontology_dict[key] = datuh
+
+            return ontology_dict
+
+        else:
+            logger.debug(f"else response: {response}")
+            return response
+
+    except Exception as e:
+        logger.error(f"Encountered problems communicating with UAZ service: {e}")
+        logger.exception(e)

--- a/api/src/ontologies.py
+++ b/api/src/ontologies.py
@@ -23,7 +23,7 @@ def get_ontology(data, type="indicator"):
         type_ = "groundModel"
     
     # Build final URL to route to UAZ
-    url_ = f"{url}/{type_}/{params}"
+    url_ = f"{url}/{type_}{params}"
 
     try:
         logger.debug(f"Sending data to {url}")

--- a/api/src/ontologies.py
+++ b/api/src/ontologies.py
@@ -14,7 +14,7 @@ def get_ontology(data, type="indicator"):
     """
     headers = {"accept": "application/json", "Content-Type": "application/json"}
     url = os.getenv("UAZ_URL")
-    params = "?maxHits=10&threshold=0.7&compositional=true"
+    params = "?maxHits=10&threshold=0.6&compositional=true"
 
     # Send to either /groundIndicator or /groundModel
     if type == "indicator":


### PR DESCRIPTION
## Description

Addresses #56.

Also includes:

* updates default log level to `INFO`, not `DEBUG`
* adds `ontologies.py` which has a more generic function to submit indicators or models to UAZ
* pulls threshold and number of hits out of function and lets them be defined in `.env`


## How to Test

You can add any model such as Google Trends or the Kimetrica Conflict model. Check in your local Dojo that it's output variables have ontology mappings. Not all will have them if there were no results from UAZ. Check the Dojo API logs for errors with `docker logs dojo-api`.

You should also "create" a single indicator and ensure that works. Try this creating (in the swagger UI) the attached example indicator.

[example_indicator.json.txt](https://github.com/jataware/dojo/files/6858676/example_indicator.json.txt)

