### PR TITLE
Notify Causemos when indicator created

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -11,3 +11,7 @@ REDIS_HOST=redis1
 UAZ_URL=http://linking.cs.arizona.edu/v1
 UAZ_THRESHOLD=0.6
 UAZ_HITS=10
+CAUSEMOS_DEBUG=true
+CAUSEMOS_USER=USER NAME HERE
+CAUSEMOS_PWD=PASSWORD HERE
+CAUSEMOS_IND_URL=https://causemos.uncharted.software/api/maas/indicators/post-process

--- a/api/src/indicators.py
+++ b/api/src/indicators.py
@@ -20,6 +20,7 @@ from src.settings import settings
 
 from src.dojo import search_and_scroll
 from src.ontologies import get_ontology
+from src.notify import notify_causemos
 import os
 
 router = APIRouter()
@@ -54,6 +55,9 @@ def create_indicator(payload: IndicatorSchema.IndicatorMetadataSchema):
     try:
         body = json.dumps(data)
         es.index(index="indicators", body=body, id=indicator_id)
+
+        # Notify Causemos that an indicator was created
+        notify_causemos(data)
 
     except Exception as e:
         logger.error(f"Issue storing indicator to elasticsearch")

--- a/api/src/notify.py
+++ b/api/src/notify.py
@@ -1,0 +1,37 @@
+import requests
+import json
+import os
+from fastapi.logger import logger
+
+
+def notify_causemos(data):
+    """
+    A function to notify Causemos that a new indicator has been created
+    POST https://causemos.uncharted.software/api/maas/indicators/post-process
+    // Request body: indicator metadata
+    """
+    headers = {"accept": "application/json", "Content-Type": "application/json"}
+
+    url = os.getenv("CAUSEMOS_IND_URL")
+    causemos_user = os.getenv("CAUSEMOS_USER")
+    causemos_pwd = os.getenv("CAUSEMOS_PWD")
+
+    try:
+        # Notify Uncharted
+        if os.getenv("CAUSEMOS_DEBUG") == "true":
+            print("Debug mode: no need to notify Uncharted")
+            return
+        else:
+            print("Notifying Uncharted...")
+            response = requests.post(
+                url,
+                headers={"Content-Type": "application/json"},
+                json=data,
+                auth=(causemos_user, causemos_pwd),
+            )
+            print(f"Response from Uncharted: {response.text}")
+            return
+
+    except Exception as e:
+        logger.error(f"Encountered problems communicating with Causemos: {e}")
+        logger.exception(e)

--- a/api/src/ontologies.py
+++ b/api/src/ontologies.py
@@ -3,9 +3,10 @@ import json
 import os
 from fastapi.logger import logger
 
+
 def get_ontology(data, type="indicator"):
     """
-    A function to submit either indicators or models to the UAZ 
+    A function to submit either indicators or models to the UAZ
     ontology mapping service
 
     Params:
@@ -14,14 +15,16 @@ def get_ontology(data, type="indicator"):
     """
     headers = {"accept": "application/json", "Content-Type": "application/json"}
     url = os.getenv("UAZ_URL")
-    params = "?maxHits=10&threshold=0.6&compositional=true"
+    uaz_threshold = os.getenv("UAZ_THRESHOLD")
+    uaz_hits = os.getenv("UAZ_HITS")
+    params = f"?maxHits={uaz_hits}&threshold={uaz_threshold}&compositional=true"
 
     # Send to either /groundIndicator or /groundModel
     if type == "indicator":
         type_ = "groundIndicator"
     elif type == "model":
         type_ = "groundModel"
-    
+
     # Build final URL to route to UAZ
     url_ = f"{url}/{type_}{params}"
 
@@ -40,8 +43,7 @@ def get_ontology(data, type="indicator"):
             ontology_dict = {}
             for ontology in ontologies["outputs"]:
                 key = ontology["name"]
-                datuh = ontology["ontologies"]
-                ontology_dict[key] = datuh
+                ontology_dict[key] = ontology["ontologies"]
 
             return ontology_dict
 


### PR DESCRIPTION
What's New:
1. Added request to Causemos endpoint:  https://causemos.uncharted.software/api/maas/indicators/post-process that posts indicator json and notifies Causemos that there is a new indicator.
2. Added environmental variables to the `.env`

Issue #57

Known Issues:
1. This code is **UNTESTED** because...
2. The Causemos endpoint it not yet deployed; Uncharted expects to deploy it tomorrow (23JUL2021)

How to test (once endpoint deployed):
1. Update Causemos creds and verify `CAUSEMOS_DEBUG=false` in the `.env`
2. Spin up local Dojo and post indicator json under create indicator
3. In dojo-api container, check the printed response from Causemos from this line: https://github.com/jataware/dojo/blob/b431d4a4fa16b161a6a208a8d059419a92b13d62/api/src/notify.py#L32
