### PR TITLE
Map UAZ ontologies to parameters, outputs, and qualifier_outputs

### DIFF
--- a/api/src/indicators.py
+++ b/api/src/indicators.py
@@ -19,7 +19,7 @@ from validation import IndicatorSchema, DojoSchema
 from src.settings import settings
 
 from src.dojo import search_and_scroll
-from src.ontologies import get_ontology
+from src.ontologies import get_ontologies
 import os
 
 router = APIRouter()
@@ -36,28 +36,10 @@ def create_indicator(payload: IndicatorSchema.IndicatorMetadataSchema):
     indicator_id = payload.id
     payload.created_at = current_milli_time()
     body = payload.json()
-    data = json.loads(body)
 
-    # TODO: UAZ API Does not return ontologies for "qualifier_outputs" so work on just "outputs" for now
-    try:
-        ontology_dict = get_ontology(data, type="indicator")
-        logger.info(f"Sent indicator to UAZ")
-        for output in data["outputs"]:
-            output["ontologies"] = ontology_dict[output["name"]]
-
-        logger.debug(f"Data with UAZ: {data}")
-
-    except Exception as e:
-        logger.error(f"Failed to generate indicator: {str(e)}")
-        logger.exception(e)
-
-    try:
-        body = json.dumps(data)
-        es.index(index="indicators", body=body, id=indicator_id)
-
-    except Exception as e:
-        logger.error(f"Issue storing indicator to elasticsearch")
-        logger.exception(e)
+    data = get_ontologies(json.loads(body), type="indicator")
+    logger.info(f"Sent indicator to UAZ")
+    es.index(index="indicators", body=data, id=indicator_id)
 
     return Response(
         status_code=status.HTTP_201_CREATED,

--- a/api/src/ontologies.py
+++ b/api/src/ontologies.py
@@ -44,7 +44,7 @@ def get_ontologies(data, type="indicator"):
                     return indicator_ontologies(data, uaz_ontologies)
                 else:
                     return model_ontologies(data, uaz_ontologies)
-            except:
+            except Exception as e:
                 # If no-go on UAZ, still return partial so it's written to ES
                 logger.error(f"Failed to generate ontologies for indicator: {str(e)}")
                 logger.exception(e)
@@ -81,8 +81,9 @@ def indicator_ontologies(data, ontologies):
     for output in data["outputs"]:
         output["ontologies"] = ontology_dict["outputs"][output["name"]]
     
-    for qualifier_output in data["qualifier_outputs"]:
-        qualifier_output["ontologies"] = ontology_dict["qualifier_outputs"][qualifier_output["name"]]
+    if data.get("qualifier_outputs", None):    
+        for qualifier_output in data["qualifier_outputs"]:
+            qualifier_output["ontologies"] = ontology_dict["qualifier_outputs"][qualifier_output["name"]]
 
     return data
 
@@ -112,10 +113,11 @@ def model_ontologies(data, ontologies):
     for parameter in data["parameters"]:
         parameter["ontologies"] = ontology_dict["parameters"][parameter["name"]]
 
-    for output in data["outputs"]:
+    for output in data.get("outputs", []):
         output["ontologies"] = ontology_dict["outputs"][output["name"]]
     
-    for qualifier_output in data["qualifier_outputs"]:
-        qualifier_output["ontologies"] = ontology_dict["qualifier_outputs"][qualifier_output["name"]]
+    if data.get("qualifier_outputs", None):
+        for qualifier_output in data["qualifier_outputs"]:
+            qualifier_output["ontologies"] = ontology_dict["qualifier_outputs"][qualifier_output["name"]]
 
     return data


### PR DESCRIPTION
Existing:
Fetch UAZ ontologies for model/indicator `outputs`

What's New:
UAZ API now supports fetching ontologies for:
model: `parameters`, `qualifier_outputs`
indicator: `qualifier_outputs`

This PR maps all  `parameters`,`outputs`, `qualifier_outputs` UAZ ontologies to the respective indicator or model.


How to test:
1. Local Dojo
2. Create an indicator and model: verify that  `parameters` (model only),`outputs`, `qualifier_outputs` have UAZ ontologies