### PR TITLE
Register model endpoint

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -14,4 +14,4 @@ UAZ_HITS=10
 CAUSEMOS_DEBUG=true
 CAUSEMOS_USER=worldmodelers
 CAUSEMOS_PWD=world!
-CAUSEMOS_IND_URL=https://causemos.uncharted.software/api/maas/indicators/post-process
+CAUSEMOS_IND_URL=https://causemos.uncharted.software/api/maas

--- a/api/src/causemos.py
+++ b/api/src/causemos.py
@@ -1,0 +1,48 @@
+import requests
+import json
+import os
+from fastapi.logger import logger
+
+
+def notify_causemos(data, type="indicator"):
+    """
+    A function to notify Causemos that a new indicator or model has been created.
+
+    If type is "indicator":
+        POST https://causemos.uncharted.software/api/maas/indicators/post-process
+        // Request body: indicator metadata
+    
+    If type is "model":
+        POST https://causemos.uncharted.software/api/maas/datacubes
+        // Request body: model metadata    
+    """
+    headers = {"accept": "application/json", "Content-Type": "application/json"}
+
+    if type == "indicator":
+        endpoint = "indicators/post-process"
+    elif type == "model":
+        endpoint - "datacubes"
+
+    url = f'{os.getenv("CAUSEMOS_IND_URL")}/{endpoint}'
+    causemos_user = os.getenv("CAUSEMOS_USER")
+    causemos_pwd = os.getenv("CAUSEMOS_PWD")
+
+    try:
+        # Notify Uncharted
+        if os.getenv("CAUSEMOS_DEBUG") == "true":
+            logger.info("CauseMos debug mode: no need to notify Uncharted")
+            return
+        else:
+            logger.info(f"Notifying CauseMos of {type} creation...")
+            response = requests.post(
+                url,
+                headers={"Content-Type": "application/json"},
+                json=data,
+                auth=(causemos_user, causemos_pwd),
+            )
+            logger.info(f"Response from Uncharted: {response.text}")
+            return
+
+    except Exception as e:
+        logger.error(f"Encountered problems communicating with Causemos: {e}")
+        logger.exception(e)

--- a/api/src/causemos.py
+++ b/api/src/causemos.py
@@ -46,3 +46,56 @@ def notify_causemos(data, type="indicator"):
     except Exception as e:
         logger.error(f"Encountered problems communicating with Causemos: {e}")
         logger.exception(e)
+
+
+def submit_run(model):
+    """
+    This function takes in a model and submits a default run for that model to CauseMos
+
+    POST https://causemos.uncharted.software/api/maas/model-runs
+    // The request body must at a minimum include
+    {
+    model_id,
+    model_name,
+    parameters,
+    is_default_run = true
+    }
+    """
+
+    headers = {"accept": "application/json", "Content-Type": "application/json"}
+    endpoint = "model-runs"
+    url = f'{os.getenv("CAUSEMOS_IND_URL")}/{endpoint}'
+    causemos_user = os.getenv("CAUSEMOS_USER")
+    causemos_pwd = os.getenv("CAUSEMOS_PWD")
+
+    params = {}
+    for param in model.get("parameters",[]):
+        params[param['name']] = param['default']
+
+    payload = {"model_id": model["id"],
+               "model_name": model["name"],
+               "parameters": params,
+               "is_default_run": True}
+
+    try:
+        # Notify Uncharted
+        if os.getenv("CAUSEMOS_DEBUG") == "true":
+            logger.info("CauseMos debug mode: no need to submit default model run to Uncharted")
+            return
+        else:
+            logger.info(f"Submitting default model run to CauseMos.")
+            response = requests.post(
+                url,
+                headers={"Content-Type": "application/json"},
+                json=payload,
+                auth=(causemos_user, causemos_pwd),
+            )
+            logger.info(f"Response from Uncharted: {response.text}")
+            return
+
+    except Exception as e:
+        logger.error(f"Encountered problems communicating with Causemos: {e}")
+        logger.exception(e)    
+
+
+

--- a/api/src/causemos.py
+++ b/api/src/causemos.py
@@ -21,7 +21,7 @@ def notify_causemos(data, type="indicator"):
     if type == "indicator":
         endpoint = "indicators/post-process"
     elif type == "model":
-        endpoint - "datacubes"
+        endpoint = "datacubes"
 
     url = f'{os.getenv("CAUSEMOS_IND_URL")}/{endpoint}'
     causemos_user = os.getenv("CAUSEMOS_USER")
@@ -72,8 +72,8 @@ def submit_run(model):
     for param in model.get("parameters",[]):
         params[param['name']] = param['default']
 
-    payload = {"model_id": model["id"],
-               "model_name": model["name"],
+    payload = {"id": model["id"],
+               "name": model["name"],
                "parameters": params,
                "is_default_run": True}
 
@@ -83,7 +83,7 @@ def submit_run(model):
             logger.info("CauseMos debug mode: no need to submit default model run to Uncharted")
             return
         else:
-            logger.info(f"Submitting default model run to CauseMos.")
+            logger.info(f"Submitting default model run to CauseMos with payload: {payload}")
             response = requests.post(
                 url,
                 headers={"Content-Type": "application/json"},

--- a/api/src/indicators.py
+++ b/api/src/indicators.py
@@ -20,7 +20,7 @@ from src.settings import settings
 
 from src.dojo import search_and_scroll
 from src.ontologies import get_ontologies
-from src.notify import notify_causemos
+from src.causemos import notify_causemos
 
 import os
 
@@ -44,7 +44,7 @@ def create_indicator(payload: IndicatorSchema.IndicatorMetadataSchema):
     es.index(index="indicators", body=data, id=indicator_id)
 
     # Notify Causemos that an indicator was created
-    notify_causemos(data)
+    notify_causemos(data, type="indicator")
     
     return Response(
         status_code=status.HTTP_201_CREATED,

--- a/api/src/models.py
+++ b/api/src/models.py
@@ -15,6 +15,7 @@ from validation import ModelSchema, DojoSchema
 from src.settings import settings
 from src.dojo import search_and_scroll
 from src.ontologies import get_ontologies
+from src.causemos import notify_causemos
 
 router = APIRouter()
 
@@ -83,3 +84,20 @@ def get_model(model_id: str) -> Model:
     except:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     return model
+
+
+@router.post("/models/register/{model_id}")
+def register_model(model_id: str):
+    """
+    This endpoint finalizes the registration of a model by notifying 
+    Uncharted and submitting to them a default run for the model.
+    """
+    model = es.get(index="models", id=model_id)["_source"]
+
+    # Notify Causemos that a model was created
+    notify_causemos(model, type="model")
+
+    return Response(
+        status_code=status.HTTP_201_CREATED,
+        content=f"Registered model to CauseMos with id = {model_id}"
+    )

--- a/api/src/models.py
+++ b/api/src/models.py
@@ -15,7 +15,7 @@ from validation import ModelSchema, DojoSchema
 from src.settings import settings
 from src.dojo import search_and_scroll
 from src.ontologies import get_ontologies
-from src.causemos import notify_causemos
+from src.causemos import notify_causemos, submit_run
 
 router = APIRouter()
 
@@ -96,6 +96,9 @@ def register_model(model_id: str):
 
     # Notify Causemos that a model was created
     notify_causemos(model, type="model")
+
+    # Send CauseMos a default run
+    submit_run(model)
 
     return Response(
         status_code=status.HTTP_201_CREATED,


### PR DESCRIPTION
Adds missing `causemos.py` file for notifying Causemos and adds `/models/register` which enables the notification of model registration to CauseMos and sends CauseMos a default model run.

## Known Issues
It does not seem like the payloads are being accepted for model registration to CauseMos. Need to confirm and update these with Uncharted.