### PR TITLE
scrape dockerhub #77

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -15,3 +15,6 @@ CAUSEMOS_DEBUG=true
 CAUSEMOS_USER=worldmodelers
 CAUSEMOS_PWD=world!
 CAUSEMOS_IND_URL=https://causemos.uncharted.software/api/maas
+DOCKERHUB_URL=https://hub.docker.com/v2
+DOCKERHUB_USER=username_here
+DOCKERHUB_PWD=pwd_here

--- a/api/src/dockerhub.py
+++ b/api/src/dockerhub.py
@@ -1,0 +1,161 @@
+"""
+    Docker Hub helper to scrape phantom images.
+    see https://docs.docker.com/docker-hub/api/latest/#
+    see https://github.com/jataware/dojo/issues/77
+    Requires credentials for Pro or Team plan.
+"""
+import json
+from logging import Logger
+import logging
+import os
+import requests
+
+logger: Logger = logging.getLogger(__name__)
+
+
+def authenticate() -> str:
+    """
+        Description
+        -----------
+        Basic authentication of Docker Hub Api. Uses base url and credentials
+        stored in .env settings.
+
+        Returns
+        -------
+        str: JWT Token
+    """
+
+    url = f'{os.getenv("DOCKERHUB_URL")}/users/login'
+    dockerhub_user = os.getenv("DOCKERHUB_USER")
+    dockerhub_pwd = os.getenv("DOCKERHUB_PWD")
+    auth_body = {"username": dockerhub_user, "password": dockerhub_pwd}
+
+    response = requests.post(url, json = auth_body, headers = {'Content-Type':'application/json'})
+    resp_json = response.json()
+
+    if 'token' in resp_json:
+        return resp_json['token']
+    else:
+        logger.error(f"Could not authenticate {url} with user {dockerhub_user}: {resp_json}")
+        return None
+
+
+def get_image_tags():
+    """
+        Description
+        -----------
+        Called by phantom.py get_base_images() to scrape DockerHub for
+        Jataware/dojo-publish images.
+
+        Returns
+        -------
+        JSON Array of
+            {
+                "sort_order": 0,
+                "display_name": "string",
+                "image": "string"
+            }
+
+    """
+
+    auth_token = authenticate()
+    if not auth_token:
+        return "" # authenticate() above will log the error
+
+    """
+        Docker Hub Url options for Get details of repository's images:
+            page_size: Number of images to get per page. Defaults to 10. Max of 100.
+            status: "active", "inactive"; Filters to only show images of this status.
+            currently_tagged: boolean; Filters to only show images with:
+            true: at least 1 current tag.
+            false: no current tags.
+            ordering: "last_activity""-last_activity""digest""-digest": Orders the results by this property.
+            Prefixing with - sorts by descending order.
+    """
+
+    url = f'{os.getenv("DOCKERHUB_URL")}/namespaces/jataware/repositories/dojo-publish/images?status=active&ordering=last_activity&currently_tagged=true&page_size=100'
+    headers = {"Accept" :"application/json", "Authorization": f"Bearer {auth_token}"}
+
+    return get_repo_image_details(url, headers)
+
+
+def get_repo_image_details(url: str, headers: dict, image_tags: list = [], sort_order: int = 0):
+    """
+        Description
+        -----------
+        GET request at Docker Hub to Get details of repository's images.
+
+        Parameters
+        ----------
+        url: str
+            Constructed url for GET.
+        headers: dict
+            Authentication headers.
+        image_tags: list
+            Current list of image tag info.
+        sort_order: int
+            Current sort_order.
+
+        Returns
+        -------
+        List of image tag info:
+            {
+                "sort_order": 0,
+                "display_name": "string",
+                "image": "string"
+            }
+
+        Notes
+        -----
+        This is built to be recursive because DockerHub will paginate the response;
+        therefore, make another call if the "next" url is returned.
+    """
+
+    try:
+        response = requests.get(url, headers = headers)
+        resp = response.json()
+
+        """
+        Example Response
+        ----------------
+            {
+            "count": 79,
+            "next": "https://hub.docker.com/v2/namespaces/jataware/repositories/dojo-publish/images?page=2&status=active",
+            "previous": null,
+            "results": [
+                {
+                    "namespace": "jataware",
+                    "repository": "dojo-publish",
+                    "digest": "sha256:81ae08c9a8093e0c0c10313b844aa70e1f5be6c582b1c1a41fc073a37df35528",
+                    "tags": [
+                        {
+                            "tag": "GoogleTrends-latest",
+                            "is_current": true
+                        }
+                    ],
+                    "last_pushed": "2021-07-15T01:16:32.454626Z",
+                    "last_pulled": "2021-07-21T14:58:42.765245Z",
+                    "status": "active"
+                },
+            ...
+        """
+        if "results" in resp:
+            for r in resp["results"]:
+                if "tags" in r:
+                    tags = r["tags"][0]
+                    tag = tags["tag"]
+                    image = r["namespace"] + "/" + r["repository"] + "/" + tag
+                    display_name = tag.replace('-latest','')
+
+                    image_tags.append( {"sort_order":sort_order, "image":image, "display_name": display_name} )
+                    sort_order += 1
+
+        # Get the next page if there is a "next".
+        if "next" in resp and resp["next"] != None:
+            image_tags = get_repo_image_details(resp["next"], headers, image_tags, sort_order)
+
+        return image_tags
+
+    except Exception as e:
+        logger.error(e.message, e.args)
+        return ""

--- a/api/src/phantom.py
+++ b/api/src/phantom.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Depends, Response
 from pydantic import BaseModel
 
 from src.redisapi import redis_pool
+from src.dockerhub import get_image_tags
 
 
 logger: Logger = logging.getLogger(__name__)
@@ -33,10 +34,12 @@ async def ping_redis(redis: aioredis.Redis = Depends(redis_pool)) -> str:
     return Response(content=str(await redis.ping()), media_type="plain/text")
 
 
+
 @router.get("/base_images")
 async def get_base_images(redis: aioredis.Redis = Depends(redis_pool)) -> List[BaseImageItem]:
-    res = await redis.hgetall(BASE_IMAGES_KEY)
-    return sorted((json.loads(x) for x in res.values()), key=lambda x: x.get("sort_order", 100) or 100)
+    #res = await redis.hgetall(BASE_IMAGES_KEY)
+    #return sorted((json.loads(x) for x in res.values()), key=lambda x: x.get("sort_order", 100) or 100)
+    return get_image_tags()
 
 
 @router.post("/base_images")
@@ -49,4 +52,3 @@ async def add_base_image(item: BaseImageItem, redis: aioredis.Redis = Depends(re
 async def delete_base_image(item: BaseImageItem, redis: aioredis.Redis = Depends(redis_pool)) -> List[BaseImageItem]:
     await redis.hdel(BASE_IMAGES_KEY, item.hash())
     return await get_base_images(redis)
-


### PR DESCRIPTION
### Description

- addresses issue #77 
- Changes `phantom.py` `get_base_images()` to get image names/tags from Docker Hub api.
- Does not modify `get_base_images()` signature.
- `dockerhub.py` methods are **not** `Async`.
- Requires .env parameters:
-- DOCKERHUB_URL=https://hub.docker.com/v2
-- DOCKERHUB_USER=_credential_username_
-- DOCKERHUB_PASSWORD=_credential_password_
- Images are returned sorted based on `last_activity`

### Testing

- modify .env with credentials that are a member of Docker Hub/jataware
- build the dojo api: `docker-compose -f docker-compose-dev.yaml up -d`
- Test via [http://localhost:8000/#/Phantom/get_base_images_phantom_base_images_get](http://localhost:8000/#/Phantom/get_base_images_phantom_base_images_get)
