### PR TITLE
remove pydantic ids for config and directive, and update dojo API endpoints

### DIFF
--- a/api/src/dojo.py
+++ b/api/src/dojo.py
@@ -102,10 +102,10 @@ def create_configs(payload: List[DojoSchema.ModelConfig]):
     maps directly to the name of a specific `parameter.
     """
     for p in payload:
-        es.index(index="configs", body=p.json(), id=p.id)
+        es.index(index="configs", body=p.json(), id=p.path)
     return Response(
         status_code=status.HTTP_201_CREATED,
-        headers={"location": f"/api/dojo/config/{p.id}"},
+        headers={"location": f"/dojo/config/{p.model_id}"},
         content=f"Created config(s) for model with id = {p.model_id}",
     )
 

--- a/api/validation/DojoSchema.py
+++ b/api/validation/DojoSchema.py
@@ -34,7 +34,6 @@ class ModelAccessory(BaseModel):
 
 
 class ModelConfig(BaseModel):
-    id: str
     model_id: str = Field(
         title="Model ID",
         description="The ID (`ModelSchema.ModelMetadata.id`) of the related model",
@@ -61,7 +60,6 @@ class ModelConfig(BaseModel):
 
 
 class ModelDirective(BaseModel):
-    id: str
     model_id: str = Field(
         title="Model ID",
         description="The ID (`ModelSchema.ModelMetadata.id`) of the related model",


### PR DESCRIPTION
per multiple conversations, these IDs serve no purpose and may cause confusion now that we're duplicating models.

let's remove them! 🚮

edit to add [corresponding commit to shorthand](https://github.com/jataware/shorthand/commit/091db80030ab6be31f9e03dab7fffc82a2745671) that removes the ID generation, and switches to to using the config's file path when generating s3 keys for the template and raw files.