### PR TITLE
Make model dates optional

### DIFF
--- a/api/validation/ModelSchema.py
+++ b/api/validation/ModelSchema.py
@@ -146,14 +146,14 @@ class Period(BaseModel):
     class Config:
         extra = Extra.allow
 
-    gte: int = Field(
-        ...,
+    gte: Optional[int] = Field(
+        None,
         description="Start Time (inclusive)",
         examples=[1234567890000],
         title="Start Time",
     )
-    lte: int = Field(
-        ...,
+    lte: Optional[int] = Field(
+        None,
         description="End Time (inclusive)",
         examples=[1234567890000],
         title="End Time",


### PR DESCRIPTION
We had the model dates optional in Phantom, but that didn't match up with the ModelSchema in Dojo so we had some funky behavior. This updates the ModelSchema to have gte and lte be optional.