### PR TITLE
model asset deletion

### DIFF
--- a/api/src/dojo.py
+++ b/api/src/dojo.py
@@ -117,7 +117,9 @@ def create_configs(payload: List[DojoSchema.ModelConfig]):
         return Response(status_code=status.HTTP_400_BAD_REQUEST,content=f"No payload")
 
     for p in payload:
-        es.index(index="configs", body=p.json(), id=p.path)
+        config_id = str(uuid.uuid4())
+        p.id = config_id
+        es.index(index="configs", body=p.json(), id=p.id)
     return Response(
         status_code=status.HTTP_201_CREATED,
         headers={"location": f"/dojo/config/{p.model_id}"},

--- a/api/validation/DojoSchema.py
+++ b/api/validation/DojoSchema.py
@@ -34,6 +34,7 @@ class ModelAccessory(BaseModel):
 
 
 class ModelConfig(BaseModel):
+    id: Optional[str]
     model_id: str = Field(
         title="Model ID",
         description="The ID (`ModelSchema.ModelMetadata.id`) of the related model",


### PR DESCRIPTION
* Add endpoints for removing assets
* Added id field to config and autosetting id to uuid on config creation
* Implemented "fuzzy" matching of configs to either match the uuid id or the sha1 hash of the path.
  * File path was the de facto id before, but can't be used as file path and url path get confused.
  * sha1 hash used to get around file path
  * sha1 logic can be removed if/when existing configs are fixed/removed.