### PR TITLE
updates to dojo endpoints for deleting configs

### DIFF
--- a/api/es-mappings/import/accessories.json
+++ b/api/es-mappings/import/accessories.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "d33cede0-0c60-4aef-87b4-76f95104a80f",
+    "model_id": "2d7b130d-4909-4338-9ac7-ebedc65cb603",
+    "path": "/home/clouseau/dummy-model/media/lime-*.jpg",
+    "caption": "Lime cat is so cool"
+  },
+  {
+    "id": "8624741d-1999-4dce-af08-0de3ef668b0a",
+    "model_id": "2d7b130d-4909-4338-9ac7-ebedc65cb603",
+    "path": "/home/clouseau/dummy-model/media/1WWMDwIQ_400x400.jpg",
+    "caption": null
+  }
+]

--- a/api/es-mappings/import/configs.json
+++ b/api/es-mappings/import/configs.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "8584cfa0-a88a-40d6-9e49-acb0d9c259a0",
+    "model_id": "2d7b130d-4909-4338-9ac7-ebedc65cb603",
+    "s3_url": "https://jataware-world-modelers.s3.amazonaws.com/dojo/shorthand_templates/2d7b130d-4909-4338-9ac7-ebedc65cb603/home/clouseau/dummy-model/configFiles/parameters.json.template.txt",
+    "s3_url_raw": "https://jataware-world-modelers.s3.amazonaws.com/dojo/shorthand_templates/2d7b130d-4909-4338-9ac7-ebedc65cb603/home/clouseau/dummy-model/configFiles/parameters.json.raw.txt",
+    "path": "/home/clouseau/dummy-model/configFiles/parameters.json"
+  },
+  {
+    "id": "9e6a30b7-ca6e-43a1-99a9-a11322e17aaa",
+    "model_id": "2d7b130d-4909-4338-9ac7-ebedc65cb603",
+    "s3_url": "https://jataware-world-modelers.s3.amazonaws.com/dojo/shorthand_templates/2d7b130d-4909-4338-9ac7-ebedc65cb603/home/clouseau/dummy-model/configFiles/fakeDataType.json.template.txt",
+    "s3_url_raw": "https://jataware-world-modelers.s3.amazonaws.com/dojo/shorthand_templates/2d7b130d-4909-4338-9ac7-ebedc65cb603/home/clouseau/dummy-model/configFiles/fakeDataType.json.raw.txt",
+    "path": "/home/clouseau/dummy-model/configFiles/fakeDataType.json"
+  }
+]

--- a/api/es-mappings/import/models.json
+++ b/api/es-mappings/import/models.json
@@ -1,0 +1,332 @@
+{
+  "id": "2d7b130d-4909-4338-9ac7-ebedc65cb603",
+  "name": "test-dummy",
+  "family_name": "test",
+  "description": "test test test test test test test test test test test test ",
+  "created_at": 1636053954506,
+  "category": [],
+  "maintainer": {
+    "name": "test",
+    "email": "test@test.com",
+    "organization": "test",
+    "website": "https://github.com/jataware/dummy-model"
+  },
+  "image": "jataware/dojo-publish:test-dummy-latest",
+  "observed_data": null,
+  "is_stochastic": false,
+  "parameters": [
+    {
+      "name": "rainfall",
+      "display_name": "rainfall",
+      "description": "rainfall setting",
+      "type": "float",
+      "unit": null,
+      "unit_description": null,
+      "ontologies": {
+        "concepts": [
+          {
+            "name": "wm/concept/health/laboratory_testing",
+            "score": 0.774978756904602
+          }
+        ],
+        "processes": [],
+        "properties": []
+      },
+      "is_drilldown": null,
+      "additional_options": null,
+      "data_type": "numerical",
+      "default": "0.9",
+      "choices": [],
+      "min": -1,
+      "max": 1,
+      "template": {
+        "mode": "config",
+        "path": "/home/clouseau/dummy-model/configFiles/parameters.json",
+        "is_editable": true,
+        "location": {
+          "col_start": 13,
+          "line": 0,
+          "col_end": 16
+        },
+        "orig_val": "0.9"
+      },
+      "id": "09-187249"
+    },
+    {
+      "name": "color",
+      "display_name": "color",
+      "description": "color choice",
+      "type": "str",
+      "unit": null,
+      "unit_description": null,
+      "ontologies": {
+        "concepts": [
+          {
+            "name": "wm/concept/health/laboratory_testing",
+            "score": 0.7662766575813293
+          }
+        ],
+        "processes": [],
+        "properties": []
+      },
+      "is_drilldown": null,
+      "additional_options": null,
+      "data_type": "freeform",
+      "default": "red",
+      "choices": [],
+      "min": null,
+      "max": null,
+      "template": {
+        "mode": "config",
+        "path": "/home/clouseau/dummy-model/configFiles/fakeDataType.json",
+        "is_editable": true,
+        "location": {
+          "col_start": 15,
+          "line": 0,
+          "col_end": 18
+        },
+        "orig_val": "red"
+      },
+      "id": "red-548922"
+    },
+    {
+      "name": "temperature",
+      "display_name": "temperature",
+      "description": "temperature setting",
+      "type": "float",
+      "unit": null,
+      "unit_description": null,
+      "ontologies": {
+        "concepts": [
+          {
+            "name": "wm/concept/health/laboratory_testing",
+            "score": 0.7835994958877563
+          }
+        ],
+        "processes": [],
+        "properties": []
+      },
+      "is_drilldown": null,
+      "additional_options": null,
+      "data_type": "numerical",
+      "default": "1.2",
+      "choices": [],
+      "min": -2,
+      "max": 2,
+      "template": {
+        "mode": "directive",
+        "path": "/home/clouseau/dummy-model",
+        "is_editable": true,
+        "location": {
+          "col_start": 23,
+          "line": 0,
+          "col_end": 26
+        },
+        "orig_val": "1.2"
+      },
+      "id": "12-114073"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "value",
+      "display_name": "Value",
+      "description": "asdf",
+      "type": "float",
+      "unit": "asdf",
+      "unit_description": "",
+      "ontologies": {
+        "concepts": [
+          {
+            "name": "wm/concept/health/laboratory_testing",
+            "score": 0.7559799551963806
+          }
+        ],
+        "processes": [],
+        "properties": []
+      },
+      "is_primary": true,
+      "additional_options": null,
+      "data_resolution": {
+        "temporal_resolution": "annual",
+        "spatial_resolution": null
+      },
+      "choices": null,
+      "min": null,
+      "max": null,
+      "uuid": "883f2e1e-e7aa-49b6-beac-7f851c901860"
+    }
+  ],
+  "qualifier_outputs": [
+    {
+      "name": "admin1",
+      "display_name": "admin1",
+      "description": "adsf",
+      "type": "admin1",
+      "unit": null,
+      "unit_description": null,
+      "ontologies": {
+        "concepts": [
+          {
+            "name": "wm/concept/health/laboratory_testing",
+            "score": 0.7585763335227966
+          }
+        ],
+        "processes": [],
+        "properties": []
+      },
+      "related_features": [
+        "value"
+      ],
+      "uuid": "883f2e1e-e7aa-49b6-beac-7f851c901860"
+    },
+    {
+      "name": "admin2",
+      "display_name": "admin2",
+      "description": "adsf",
+      "type": "admin2",
+      "unit": null,
+      "unit_description": null,
+      "ontologies": {
+        "concepts": [
+          {
+            "name": "wm/concept/health/laboratory_testing",
+            "score": 0.7517799139022827
+          }
+        ],
+        "processes": [],
+        "properties": []
+      },
+      "related_features": [
+        "value"
+      ],
+      "uuid": "883f2e1e-e7aa-49b6-beac-7f851c901860"
+    },
+    {
+      "name": "admin3",
+      "display_name": "admin3",
+      "description": "adsf",
+      "type": "admin3",
+      "unit": null,
+      "unit_description": null,
+      "ontologies": {
+        "concepts": [
+          {
+            "name": "wm/concept/health/laboratory_testing",
+            "score": 0.7585763335227966
+          }
+        ],
+        "processes": [],
+        "properties": []
+      },
+      "related_features": [
+        "value"
+      ],
+      "uuid": "883f2e1e-e7aa-49b6-beac-7f851c901860"
+    },
+    {
+      "name": "country",
+      "display_name": "country",
+      "description": "adsf",
+      "type": "country",
+      "unit": null,
+      "unit_description": null,
+      "ontologies": {
+        "concepts": [
+          {
+            "name": "wm/concept/health/laboratory_testing",
+            "score": 0.7665456533432007
+          }
+        ],
+        "processes": [],
+        "properties": []
+      },
+      "related_features": [
+        "value"
+      ],
+      "uuid": "883f2e1e-e7aa-49b6-beac-7f851c901860"
+    },
+    {
+      "name": "lat",
+      "display_name": "lat",
+      "description": "adsf",
+      "type": "lat",
+      "unit": null,
+      "unit_description": null,
+      "ontologies": {
+        "concepts": [
+          {
+            "name": "wm/concept/health/laboratory_testing",
+            "score": 0.7562645077705383
+          }
+        ],
+        "processes": [],
+        "properties": []
+      },
+      "related_features": [
+        "value"
+      ],
+      "uuid": "883f2e1e-e7aa-49b6-beac-7f851c901860"
+    },
+    {
+      "name": "lng",
+      "display_name": "lng",
+      "description": "adsf",
+      "type": "lng",
+      "unit": null,
+      "unit_description": null,
+      "ontologies": {
+        "concepts": [
+          {
+            "name": "wm/concept/health/laboratory_testing",
+            "score": 0.7568359375
+          }
+        ],
+        "processes": [],
+        "properties": []
+      },
+      "related_features": [
+        "value"
+      ],
+      "uuid": "883f2e1e-e7aa-49b6-beac-7f851c901860"
+    },
+    {
+      "name": "timestamp",
+      "display_name": "timestamp",
+      "description": "asdf",
+      "type": "datetime",
+      "unit": "date",
+      "unit_description": null,
+      "ontologies": {
+        "concepts": [
+          {
+            "name": "wm/concept/health/laboratory_testing",
+            "score": 0.7463858127593994
+          }
+        ],
+        "processes": [],
+        "properties": []
+      },
+      "related_features": [
+        "value"
+      ],
+      "uuid": "883f2e1e-e7aa-49b6-beac-7f851c901860"
+    }
+  ],
+  "tags": null,
+  "geography": {
+    "country": null,
+    "admin1": null,
+    "admin2": null,
+    "admin3": null,
+    "coordinates": []
+  },
+  "period": {
+    "gte": 1577858400000,
+    "lte": 1612245600000
+  },
+  "next_version": null,
+  "prev_version": "a31fdf63-2717-4b69-b4a2-7f0c0c530de9",
+  "stochastic": "true",
+  "type": "model"
+}

--- a/api/es-mappings/import/outputfiles.json
+++ b/api/es-mappings/import/outputfiles.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "883f2e1e-e7aa-49b6-beac-7f851c901860",
+    "model_id": "2d7b130d-4909-4338-9ac7-ebedc65cb603",
+    "name": "asdf",
+    "output_directory": "/home/clouseau/dummy-model/output",
+    "path": "output_*_*.csv",
+    "file_type": "csv",
+    "transform": {
+      "geo": [
+        {
+          "name": "longitude",
+          "display_name": "longitude",
+          "description": "adsf",
+          "type": "geo",
+          "geo_type": "longitude",
+          "primary_geo": true,
+          "is_geo_pair": "latitude"
+        },
+        {
+          "name": "latitude",
+          "display_name": "Latitude",
+          "description": "adsf",
+          "type": "geo",
+          "geo_type": "latitude",
+          "primary_geo": true,
+          "is_geo_pair": "longitude"
+        }
+      ],
+      "date": [
+        {
+          "name": "date",
+          "display_name": "Date",
+          "description": "asdf",
+          "type": "date",
+          "date_type": "date",
+          "time_format": "%Y-%m-%d",
+          "primary_date": true
+        }
+      ],
+      "feature": [
+        {
+          "name": "value",
+          "display_name": "Value",
+          "description": "asdf",
+          "type": "feature",
+          "feature_type": "float",
+          "units": "asdf",
+          "units_description": ""
+        }
+      ],
+      "meta": {
+        "ftype": "csv"
+      }
+    },
+    "prev_id": null
+  }
+]

--- a/api/src/dojo.py
+++ b/api/src/dojo.py
@@ -101,16 +101,12 @@ def import_json_data():
 
         print(f"Importing {file} into {index}", flush=True)
         data = json.loads(open(file).read())
-        if type(data) != list:
-            print(data, flush=True)
-            result = es.index(index=index, body=data, id=data["id"])
-        else:
+        if type(data) == list:
             for x in data:
                 result = es.index(index=index, body=x, id=x["id"])
+        else:
+            result = es.index(index=index, body=data, id=data["id"])
 
-        # result = es.indices.create(index, body=data)
-        # result = es.index(index=index, body=data)
-        # print(result)
     return Response(
         status_code=status.HTTP_200_OK,
         content=f"Imported",

--- a/api/src/dojo.py
+++ b/api/src/dojo.py
@@ -181,6 +181,7 @@ def delete_config(model_id: str, path: str):
         params_to_delete = []
         for param in params:
             if param.get("template", {}).get("path") == path:
+                # TODO: see if this same param exists in other configs or directives?
                 params_to_delete.append(param)
 
         for param in params_to_delete:

--- a/api/src/dojo.py
+++ b/api/src/dojo.py
@@ -143,6 +143,12 @@ def create_configs(payload: List[DojoSchema.ModelConfig]):
         return Response(status_code=status.HTTP_400_BAD_REQUEST,content=f"No payload")
 
     for p in payload:
+
+        # remove existing configs with this model_id and path
+        response = es.search(index="configs", body=search_for_config(p.model_id, p.path))
+        for hit in response["hits"]["hits"]:
+            es.delete(index="configs", id=hit["_id"])
+
         es.index(index="configs", body=p.json())
     return Response(
         status_code=status.HTTP_201_CREATED,

--- a/api/src/dojo.py
+++ b/api/src/dojo.py
@@ -291,11 +291,20 @@ def delete_outputfile(outputfile_id: str):
     """
 
     try:
+
+        outputfile = es.get(index="outputfiles", id=outputfile_id)["_source"]
+
+        # search the model for outputs that use this outputfile's ID
+        def output_matches(output):
+            return output.get("uuid") == outputfile_id
+        output_count = delete_matching_records_from_model(outputfile["model_id"], "outputs", output_matches)
+
         es.delete(index="outputfiles", id=outputfile_id)
+
         return Response(
             status_code=status.HTTP_200_OK,
             headers={"location": f"/dojo/outputfile/{outputfile_id}"},
-            content=f"Deleted outputfile with id = {outputfile_id}",
+            content=f"Deleted outputfile and {output_count} output(s) with id = {outputfile_id}",
         )
     except NotFoundError:
         return Response(

--- a/api/src/dojo.py
+++ b/api/src/dojo.py
@@ -197,6 +197,8 @@ def delete_config(model_id: str, path: str):
             params.remove(param)
 
         modify_model(config["model_id"], ModelSchema.ModelMetadataPatchSchema(parameters=params))
+
+        # TODO remove s3_url and s3_url_raw from s3?
         es.delete(index="configs", id=hit["_id"])
 
     return Response(

--- a/api/src/dojo.py
+++ b/api/src/dojo.py
@@ -84,6 +84,33 @@ def search_and_scroll(index, query=None, size=10, scroll_id=None):
     }
 
 
+@router.get("/dojo/es-mappings/import")
+def import_outputfiles():
+    from glob import glob
+    import json
+
+    for file in glob("es-mappings/import/*", recursive=True):
+
+        index = file.split("/")[-1].split(".json")[0]
+
+        print(f"Importing {file} into {index}", flush=True)
+        data = json.loads(open(file).read())
+        if type(data) != list:
+            print(data, flush=True)
+            result = es.index(index=index, body=data, id=data["id"])
+        else:
+            for x in data:
+                result = es.index(index=index, body=x, id=x["id"])
+
+        # result = es.indices.create(index, body=data)
+        # result = es.index(index=index, body=data)
+        # print(result)
+    return Response(
+        status_code=status.HTTP_200_OK,
+        content=f"Imported",
+    )
+
+
 @router.post("/dojo/directive")
 def create_directive(payload: DojoSchema.ModelDirective):
     """

--- a/api/src/dojo.py
+++ b/api/src/dojo.py
@@ -24,6 +24,31 @@ def search_by_model(model_id):
     q = {"query": {"term": {"model_id.keyword": {"value": model_id, "boost": 1.0}}}}
     return q
 
+def search_for_config(model_id, path):
+    q = {
+        "query": {
+            "bool": {
+                "must": [
+                    {
+                        "match": {
+                            "model_id": {
+                                "query": model_id,
+                            },
+                        },
+                    },
+                    {
+                        "match": {
+                            "path": {
+                                "query": path,
+                            },
+                        },
+                    }
+                ]
+            }
+        }
+    }
+    return q
+
 
 def search_and_scroll(index, query=None, size=10, scroll_id=None):
     if query:
@@ -145,28 +170,7 @@ def delete_config(model_id: str, path: str):
     """
     from src.models import get_model, modify_model  # import at runtime to avoid circular import error
 
-    response = es.search(index="configs", body={
-        "query": {
-            "bool": {
-                "must": [
-                    {
-                        "match": {
-                            "model_id": {
-                                "query": model_id,
-                            },
-                        },
-                    },
-                    {
-                        "match": {
-                            "path": {
-                                "query": path,
-                            },
-                        },
-                    }
-                ]
-            }
-        }
-    })
+    response = es.search(index="configs", body=search_for_config(model_id, path))
 
     config_count, param_count = 0, 0
     for hit in response["hits"]["hits"]:

--- a/api/src/dojo.py
+++ b/api/src/dojo.py
@@ -298,13 +298,14 @@ def delete_outputfile(outputfile_id: str):
         def output_matches(output):
             return output.get("uuid") == outputfile_id
         output_count = delete_matching_records_from_model(outputfile["model_id"], "outputs", output_matches)
+        qualifier_output_count = delete_matching_records_from_model(outputfile["model_id"], "qualifier_outputs", output_matches)
 
         es.delete(index="outputfiles", id=outputfile_id)
 
         return Response(
             status_code=status.HTTP_200_OK,
             headers={"location": f"/dojo/outputfile/{outputfile_id}"},
-            content=f"Deleted outputfile and {output_count} output(s) with id = {outputfile_id}",
+            content=f"Deleted outputfile, {output_count} output(s) and {qualifier_output_count} qualifier output(s) with outputfile_id = {outputfile_id}",
         )
     except NotFoundError:
         return Response(

--- a/api/src/dojo.py
+++ b/api/src/dojo.py
@@ -84,8 +84,14 @@ def search_and_scroll(index, query=None, size=10, scroll_id=None):
     }
 
 
-@router.get("/dojo/es-mappings/import")
-def import_outputfiles():
+@router.get("/dojo/import")
+def import_json_data():
+    """
+    In order to facilitate testing, you can place json files in the `es-mappings/import` directory
+    with the ES index name as the file name, such as `es-mappings/import/models.json`. Visiting this endpoint
+    will import the data in those files and save it to the local elasticsearch instances.
+    """
+
     from glob import glob
     import json
 

--- a/api/src/dojo.py
+++ b/api/src/dojo.py
@@ -272,13 +272,13 @@ def delete_outputfile(outputfile_id: str):
         return Response(
             status_code=status.HTTP_200_OK,
             headers={"location": f"/dojo/outputfile/{outputfile_id}"},
-            content=f"Deleted outputfile for model with id = {outputfile_id}",
+            content=f"Deleted outputfile with id = {outputfile_id}",
         )
     except NotFoundError:
         return Response(
-            status_code=status.HTTP_200_OK,
+            status_code=status.HTTP_404_NOT_FOUND,
             headers={"location": f"/dojo/outputfile/{outputfile_id}"},
-            content=f"Deleted outputfile for model with id = {outputfile_id}",
+            content=f"Couldn't find the output file with id = {outputfile_id}",
         )
 
 

--- a/api/src/dojo.py
+++ b/api/src/dojo.py
@@ -118,9 +118,7 @@ def create_configs(payload: List[DojoSchema.ModelConfig]):
         return Response(status_code=status.HTTP_400_BAD_REQUEST,content=f"No payload")
 
     for p in payload:
-        config_id = str(uuid.uuid4())
-        p.id = config_id
-        es.index(index="configs", body=p.json(), id=p.id)
+        es.index(index="configs", body=p.json())
     return Response(
         status_code=status.HTTP_201_CREATED,
         headers={"location": f"/dojo/config/{p.model_id}"},

--- a/api/src/utils.py
+++ b/api/src/utils.py
@@ -7,6 +7,14 @@ def try_parse_int(s: str, default: int = 0) -> int:
         return default
 
 def delete_matching_records_from_model(model_id, record_key, record_test):
+    """
+    This function provides an easy way to remove information from within a specific key of a model.
+
+    - model_id: the id of the model that we should be removing information from
+    - record_key: the key of the model that we should look in to remove data (ie "parameters", "outputs")
+    - record_test: a function that will run on each of the records within the record_key to see whether
+        they should be deleted. record_test() should return True if this record is to be deleted
+    """
 
     from src.models import get_model, modify_model  # import at runtime to avoid circular import error
     record_count = 0

--- a/api/src/utils.py
+++ b/api/src/utils.py
@@ -1,5 +1,28 @@
+from validation import ModelSchema
+
 def try_parse_int(s: str, default: int = 0) -> int:
     try:
         return int(s)
     except ValueError:
         return default
+
+def delete_matching_records_from_model(model_id, record_key, record_test):
+
+    from src.models import get_model, modify_model  # import at runtime to avoid circular import error
+    record_count = 0
+
+    model = get_model(model_id)
+    records = model.get(record_key, [])
+    records_to_delete = []
+    for record in records:
+        if record_test(record):
+            records_to_delete.append(record)
+
+    for record in records_to_delete:
+        record_count += 1
+        records.remove(record)
+
+    update = { record_key: records }
+    modify_model(model_id, ModelSchema.ModelMetadataPatchSchema(**update))
+
+    return record_count

--- a/api/validation/DojoSchema.py
+++ b/api/validation/DojoSchema.py
@@ -34,7 +34,6 @@ class ModelAccessory(BaseModel):
 
 
 class ModelConfig(BaseModel):
-    id: Optional[str]
     model_id: str = Field(
         title="Model ID",
         description="The ID (`ModelSchema.ModelMetadata.id`) of the related model",


### PR DESCRIPTION
PR for #108 that adds logic to the DELETE `/dojo/configs/{model_id}` endpoint.

Note that I changed the endpoint from using a `config_id` to using the `model_id` (in the URL path) and a query argument for the config file's `path`. This aligns dojo's logic with how shorthand is expecting to refer to configs. 

As discussed previously, configs (as well as directives) don't really have logical IDs that are stored or referenced anywhere else. Instead, configs can be uniquely identified by the combination of model_id and config file path. I imagine that any phantom code that would be pinging dojo to delete a config wouldn't necessarily have the config's ID, but it would have the model_id and the path to the config file (since these are are stored in `model["parameters"][...]["template"]`), so I built the endpoint around that.

I also discovered that we weren't properly deduping configs when making a POST request to `/dojo/configs/`, again since the config's GUID wasn't something shorthand knew about or could dedupe on. So I updated that endpoint to lookup/delete other configs with the same model_id/path combo.