### PR TITLE
Feature/rtk chirps

### DIFF
--- a/models/chirps/run_chirps_tiff.py
+++ b/models/chirps/run_chirps_tiff.py
@@ -4,10 +4,9 @@ Usage:
 
 Requirements:
     pyproj==2.6.1.post1
-    mixmasta==0.5.19
+    mixmasta>=0.5.19
 '''
 
-from os import sched_getscheduler
 import requests
 import logging
 from pyproj import Proj, transform
@@ -15,7 +14,6 @@ import argparse
 import json
 import sys
 import warnings
-#from mixmasta import mixmasta as mix
 from datetime import datetime
 import pandas as pd
 import rioxarray as rxr
@@ -25,13 +23,72 @@ if not sys.warnoptions:
     warnings.simplefilter("ignore")
 
 
-# Stat : Column-Name dictionary.
-stat_choices = { 'mm_data':'rainfall','mm_anomaly':'anomaly','none_z-score':'z-score'}
+# Statistic : Output Column-Name dictionary.
+stat_choices = { 'mm_data': 'rainfall', 'mm_anomaly': 'anomaly', 'none_z-score': 'z-score'}
 
 class CHIRPSController(object):
     """
     A controller to manage CHIRPS model execution.
     """
+
+
+    def process_download(self, df: pd.DataFrame, date: str):
+        """
+        Description
+        -----------
+            Read the file downloaded by run_model (which sets the download_filename)
+            and add to the DataFrame parameter.
+
+        Parameters
+        ----------
+            df: pd.DataFrame
+                Working output dataframe of combined downloads.
+            date: str
+                Date string for the first download df or adding a df on axis 0 (rows).        
+
+        Returns
+        -------
+            pd.DataFrame: the modified dataframe.
+
+        """
+        # Open the downloaded .tiff and convert to a dataframe; remove 'spatial-ref' column.
+        ds = rxr.open_rasterio(self.download_filename, masked=True)
+        feature_name = stat_choices[self.stat]
+        df_model1 = ds.to_dataframe(name=feature_name)
+        del df_model1['spatial_ref']
+
+        # Add the date col or concatenate if not the first download.
+        if df.empty:
+            df_model1['date'] = date
+            df = df_model1
+        else:
+            df = pd.concat([df, df_model1], axis = 1)
+
+        # Remove download file.
+        os.remove(self.download_filename)
+        return df
+
+    def set_days_of_year(self):
+        """
+        Description
+        -----------
+            Used for CHIRP-GEFS when month is passed. 
+            Set list of day-of-years for the 1st and 16th of the self.month or self.day_of_year.
+
+        Returns
+        -------
+            [int] : array of day-of-year ints.
+        """
+        if self.month != None:
+            date = datetime.strptime(f"{self.month}/01/{self.year}", "%m/%d/%Y")
+            
+        else:
+            # day_of_year passed
+            date = datetime.strptime(f"{self.year}-{self.day_of_year}", "%Y-%j").strftime("%m-1-%Y")
+
+        doy = date.timetuple().tm_yday
+        self.days_of_year = [doy, doy + 15]
+
 
     def __init__(self, name, month, year, bbox, statistic, day_of_year=None):
         logging.basicConfig(level=logging.INFO)        
@@ -45,6 +102,9 @@ class CHIRPSController(object):
         stat_secondary = {'mm_data': 'Data'}
         self.set_url()
         self.set_url_gefs()
+        self.download_filename = f"results/chirps-{statistic}.tiff"
+
+        self.set_days_of_year()
 
         self.features = {'mm_data': {
                                 'feature_name': 'Rainfall',
@@ -71,52 +131,67 @@ class CHIRPSController(object):
                    f"&wcsURLToUse=https://chc-ewx2.chc.ucsb.edu:8443/geoserver/wcs?&resolution=0.05&srsToUse=EPSG:3857&outputSrsToUse=EPSG:4326"
 
     def set_url_gefs(self):
-        self.url_gefs = f"https://chc-ewx2.chc.ucsb.edu/proxies/wcsProxy.php?layerNameToUse=chirpsgefs15day2:chirpsgefs15day2_africa_1"\
-                        f"-day-{self.day_of_year}-{self.year}_{self.stat}&TILED=true&mapperWMSURL="\
-                        f"&lowerLeftXToUse={self.min_pt[0]}&lowerLeftYToUse={self.min_pt[1]}"\
-                        f"&upperRightXToUse={self.max_pt[0]}&upperRightYToUse={self.max_pt[1]}"\
-                        f"&wcsURLToUse=https://chc-ewx2.chc.ucsb.edu:8443/geoserver/wcs?&resolution=0.05&srsToUse=EPSG:3857&outputSrsToUse=EPSG:4326"
+        # f"-day-{self.day_of_year}-{self.year}_{self.stat}&TILED=true&mapperWMSURL="\
+        self.url_gefs = f"https://chc-ewx2.chc.ucsb.edu/proxies/wcsProxy.php?layerNameToUse=chirpsgefs15day2:"\
+                    f"chirpsgefs15day2_africa_1"\
+                    f"-day-{self.day_of_year}-{self.year}_{self.stat}"\
+                    f"&lowerLeftXToUse={self.min_pt[0]}&lowerLeftYToUse={self.min_pt[1]}"\
+                    f"&upperRightXToUse={self.max_pt[0]}&upperRightYToUse={self.max_pt[1]}"\
+                    f"&wcsURLToUse=https://chc-ewx2.chc.ucsb.edu:8443/geoserver/wcs?&resolution=0.05&srsToUse=EPSG:3857&outputSrsToUse=EPSG:4326"
 
     def run_models(self):
         """
-        (1)
-        Get tiffs for the three stats using the existing run_model() method
-        modified to append the saved filename with the stat e.g. results/chirps-mm_data.tiff.
+        Description
+        -----------
+            (1)
+            Get tiffs for the three stats using the existing run_model() method
+            modified to append the saved filename with the stat e.g. results/chirps-mm_data.tiff.
 
-        (2)
-        Convert each saved tiff to a dataframe and append columns to earlier df.
+            (2)
+            Convert each saved tiff to a dataframe and append columns to earlier df.
+
+            (3) 
+            Flow control is by self.name CHIRPS or CHIRPS-GEFS.
+
+            (4) 
+            CHIRPS-GEFS calculates the day-of-year for the 1st and 16th of the month, and 
+            makes a call for each statistic for both day-of-years. The day-of-year DataFrames
+            are concatenated by row. Therefore, the 'date' column will contain two unique dates.
+
+        Output
+        ------
+            Saves concatenated dataframe to results/chirps.csv.
         """
 
-        df = pd.DataFrame()
-        for stat in stat_choices.keys():
-            download_filename = f"results/chirps-{stat}.tiff"
-            
-            self.stat = stat
-            self.run_model()
+        if self.name == 'CHIRPS-GEFS':
+            df1 = pd.DataFrame
+            df16 = pd.DataFrame
+            for doy in self.days_of_year:
+                for stat in stat_choices.keys():
+                    self.download_filename = f"results/chirps-{stat}.tiff"
+                    self.stat = stat
+                    self.run_model()
+                    date = datetime.strptime(f"{self.year}-{doy}", "%Y-%j").strftime("%m-%d-%Y")
+                    self.set_url_gefs()
+                    if doy == 1:
+                        df1 = self.process_download(df1, date)
+                    else:
+                        df16 = self.process_download(df16, date)
 
-            # Set the date format and url based on endpoint.
-            if args.name == 'CHIRPS-GEFS':
-                date = datetime.strptime(f"{self.year}-{self.day_of_year}", "%Y-%j").strftime("%m-%d-%Y")
-                self.set_url_gefs()
-            else:
+            # Concat the two month dataframes by row.
+            df = pd.concat([df1, df16], axis=0)
+
+        else:
+            df = pd.DataFrame()
+            for stat in stat_choices.keys():
+                self.download_filename = f"results/chirps-{stat}.tiff"                
+                self.stat = stat
+                self.run_model()
+
+                # For CHIRPS we download only the 1st of the month.
                 date = f"{month}/01/{self.year}"
                 self.set_url()
-
-            # Open the downloaded .tiff and convert to a dataframe; remove 'spatial-ref' column.
-            ds = rxr.open_rasterio(download_filename, masked=True)
-            feature_name = stat_choices[self.stat]
-            df_model1 = ds.to_dataframe(name=feature_name)
-            del df_model1['spatial_ref']
-
-            # Add the date col or concatenate if not the first download.
-            if df.empty:
-                df_model1['date'] = date
-                df = df_model1
-            else:
-                df = pd.concat([df, df_model1], axis = 1)
-
-            # Remove download file.
-            os.remove(download_filename)
+                df = self.process_download(df, date)
 
         # Convert the MultiIndex to columns, remove 'band' column, and reorder the columns. 
         df.reset_index(inplace=True)          
@@ -124,13 +199,15 @@ class CHIRPSController(object):
         cols = ['x','y','date'] + list (stat_choices.values())
         df = df[cols]
         df.to_csv('results/chirps.csv')
-
+        logging.info('Processing completed. Output to results/chirps.csv. Header and tail preview:')
+        logging.info(df.head())
+        logging.info(df.tail())
 
     def run_model(self):
         """
-        Obtain CHIRPS data
+        Obtain CHIRPS data.
         """
-  
+
         try:
             # if CHIRPS-GEFS, use that URL
             if self.name == 'CHIRPS-GEFS':
@@ -144,7 +221,7 @@ class CHIRPSController(object):
                 
             logging.info("Model run: SUCCESS")
 
-            with open(f"results/chirps-{self.stat}.tiff", "wb") as f:
+            with open(self.download_filename, "wb") as f:
                 f.write(data.content)
 
         except Exception as e:
@@ -167,10 +244,10 @@ class CHIRPSController(object):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description = 'CHIRPS runner')
     parser.add_argument('--name', type=str, help='CHIRPS or CHIRPS-GEFS')
-    parser.add_argument('--day_of_year', type=str, help='day of year (1 to 365)', default=None)
-    parser.add_argument('--month', type=int, help='month')
+    parser.add_argument('--day_of_year', type=str, help='day of year (1 to 365) for CHIRPS-GEFS', default=None)
+    parser.add_argument('--month', type=int, help='month for CHIRPS')
     parser.add_argument('--year', type=int, help='Year')
-    parser.add_argument('--bbox', type=str, help='The bounding box to obtain')
+    parser.add_argument('--bbox', type=str, help="The bounding box to obtain e.g. '[33.512234, 2.719907, 49.98171,16.501768]'")
     parser.add_argument('--statistic', choices=stat_choices.keys(), help='The statistic to fetch')
     args = parser.parse_args()    
 
@@ -181,29 +258,3 @@ if __name__ == '__main__':
 
     runner = CHIRPSController(args.name, month, args.year, args.bbox, args.statistic, args.day_of_year)
     runner.run_models()
-
-    #if args.name == 'CHIRPS-GEFS':
-    #    date = datetime.strptime(f"{args.year}-{args.day_of_year}", "%Y-%j").strftime("%m-%d-%Y")
-    #else:
-    #    date = f"{month}/01/{args.year}"
-    
-    #df = mix.raster2df(f"results/chirps-{args.statistic}.tiff", feature_name='rainfall', band=1, date=date)
-    #df['type'] = runner.features[args.statistic]['feature_name']
-    #df.to_csv(f'results/chirps-{args.statistic}.csv', index=False)
-
-
-    '''
-    name = 'CHIRPS'
-    month = '01'
-    year = '2020'
-    bbox='[33.512234, 2.719907, 49.98171,16.501768]'
-    statistic='mm_data'
-    day_of_year = None
-    runner = CHIRPSController(name, month, year, bbox, statistic, day_of_year)
-    runner.run_model()
-
-    date = f"{month}/01/{year}"
-    df = mix.raster2df('examples/results/chirps.tiff', feature_name='rainfall', band=1, date=date)
-    df['type'] = runner.features[statistic]['feature_name']
-    df.to_csv('exmaples/results/chirps.csv', index=False)
-    '''

--- a/models/chirps/run_chirps_tiff.py
+++ b/models/chirps/run_chirps_tiff.py
@@ -7,6 +7,7 @@ Requirements:
     mixmasta==0.5.19
 '''
 
+from os import sched_getscheduler
 import requests
 import logging
 from pyproj import Proj, transform
@@ -14,12 +15,18 @@ import argparse
 import json
 import sys
 import warnings
-from mixmasta import mixmasta as mix
+#from mixmasta import mixmasta as mix
 from datetime import datetime
+import pandas as pd
+import rioxarray as rxr
+import os
 
 if not sys.warnoptions:
     warnings.simplefilter("ignore")
 
+
+# Stat : Column-Name dictionary.
+stat_choices = { 'mm_data':'rainfall','mm_anomaly':'anomaly','none_z-score':'z-score'}
 
 class CHIRPSController(object):
     """
@@ -36,16 +43,8 @@ class CHIRPSController(object):
         self.bbox = json.loads(bbox)
         self.min_pt, self.max_pt = self.convert_bbox(self.bbox)
         stat_secondary = {'mm_data': 'Data'}
-        self.url = f"https://chc-ewx2.chc.ucsb.edu/proxies/wcsProxy.php?layerNameToUse=chirps:"\
-                   f"chirps_africa_1-month-{self.month}-{self.year}_{self.stat}"\
-                   f"&lowerLeftXToUse={self.min_pt[0]}&lowerLeftYToUse={self.min_pt[1]}"\
-                   f"&upperRightXToUse={self.max_pt[0]}&upperRightYToUse={self.max_pt[1]}"\
-                   f"&wcsURLToUse=https://chc-ewx2.chc.ucsb.edu:8443/geoserver/wcs?&resolution=0.05&srsToUse=EPSG:3857&outputSrsToUse=EPSG:4326"
-        self.url_gefs = f"https://chc-ewx2.chc.ucsb.edu/proxies/wcsProxy.php?layerNameToUse=chirpsgefs15day2:chirpsgefs15day2_africa_1"\
-                        f"-day-{self.day_of_year}-{self.year}_{self.stat}&TILED=true&mapperWMSURL="\
-                        f"&lowerLeftXToUse={self.min_pt[0]}&lowerLeftYToUse={self.min_pt[1]}"\
-                        f"&upperRightXToUse={self.max_pt[0]}&upperRightYToUse={self.max_pt[1]}"\
-                        f"&wcsURLToUse=https://chc-ewx2.chc.ucsb.edu:8443/geoserver/wcs?&resolution=0.05&srsToUse=EPSG:3857&outputSrsToUse=EPSG:4326"
+        self.set_url()
+        self.set_url_gefs()
 
         self.features = {'mm_data': {
                                 'feature_name': 'Rainfall',
@@ -64,24 +63,90 @@ class CHIRPSController(object):
                                     }
                         }
 
+    def set_url(self):
+        self.url = f"https://chc-ewx2.chc.ucsb.edu/proxies/wcsProxy.php?layerNameToUse=chirps:"\
+                   f"chirps_africa_1-month-{self.month}-{self.year}_{self.stat}"\
+                   f"&lowerLeftXToUse={self.min_pt[0]}&lowerLeftYToUse={self.min_pt[1]}"\
+                   f"&upperRightXToUse={self.max_pt[0]}&upperRightYToUse={self.max_pt[1]}"\
+                   f"&wcsURLToUse=https://chc-ewx2.chc.ucsb.edu:8443/geoserver/wcs?&resolution=0.05&srsToUse=EPSG:3857&outputSrsToUse=EPSG:4326"
+
+    def set_url_gefs(self):
+        self.url_gefs = f"https://chc-ewx2.chc.ucsb.edu/proxies/wcsProxy.php?layerNameToUse=chirpsgefs15day2:chirpsgefs15day2_africa_1"\
+                        f"-day-{self.day_of_year}-{self.year}_{self.stat}&TILED=true&mapperWMSURL="\
+                        f"&lowerLeftXToUse={self.min_pt[0]}&lowerLeftYToUse={self.min_pt[1]}"\
+                        f"&upperRightXToUse={self.max_pt[0]}&upperRightYToUse={self.max_pt[1]}"\
+                        f"&wcsURLToUse=https://chc-ewx2.chc.ucsb.edu:8443/geoserver/wcs?&resolution=0.05&srsToUse=EPSG:3857&outputSrsToUse=EPSG:4326"
+
+    def run_models(self):
+        """
+        (1)
+        Get tiffs for the three stats using the existing run_model() method
+        modified to append the saved filename with the stat e.g. results/chirps-mm_data.tiff.
+
+        (2)
+        Convert each saved tiff to a dataframe and append columns to earlier df.
+        """
+
+        df = pd.DataFrame()
+        for stat in stat_choices.keys():
+            download_filename = f"results/chirps-{stat}.tiff"
+            
+            self.stat = stat
+            self.run_model()
+
+            # Set the date format and url based on endpoint.
+            if args.name == 'CHIRPS-GEFS':
+                date = datetime.strptime(f"{self.year}-{self.day_of_year}", "%Y-%j").strftime("%m-%d-%Y")
+                self.set_url_gefs()
+            else:
+                date = f"{month}/01/{self.year}"
+                self.set_url()
+
+            # Open the downloaded .tiff and convert to a dataframe; remove 'spatial-ref' column.
+            ds = rxr.open_rasterio(download_filename, masked=True)
+            feature_name = stat_choices[self.stat]
+            df_model1 = ds.to_dataframe(name=feature_name)
+            del df_model1['spatial_ref']
+
+            # Add the date col or concatenate if not the first download.
+            if df.empty:
+                df_model1['date'] = date
+                df = df_model1
+            else:
+                df = pd.concat([df, df_model1], axis = 1)
+
+            # Remove download file.
+            os.remove(download_filename)
+
+        # Convert the MultiIndex to columns, remove 'band' column, and reorder the columns. 
+        df.reset_index(inplace=True)          
+        del df['band']
+        cols = ['x','y','date'] + list (stat_choices.values())
+        df = df[cols]
+        df.to_csv('results/chirps.csv')
+
+
     def run_model(self):
         """
         Obtain CHIRPS data
         """
-        logging.info(self.url_gefs)
+  
         try:
             # if CHIRPS-GEFS, use that URL
             if self.name == 'CHIRPS-GEFS':
+                logging.info(self.url_gefs)
                 data = requests.get(self.url_gefs)
 
             # otherwise, use CHRIPS URL 
             else:
+                logging.info(self.url)
                 data = requests.get(self.url)
                 
             logging.info("Model run: SUCCESS")
 
-            with open("results/chirps.tiff", "wb") as f:
+            with open(f"results/chirps-{self.stat}.tiff", "wb") as f:
                 f.write(data.content)
+
         except Exception as e:
             logging.error(f"CHIRPS Fail: {e}")
 
@@ -106,7 +171,7 @@ if __name__ == '__main__':
     parser.add_argument('--month', type=int, help='month')
     parser.add_argument('--year', type=int, help='Year')
     parser.add_argument('--bbox', type=str, help='The bounding box to obtain')
-    parser.add_argument('--statistic', choices=['mm_data','mm_anomaly','none_z-score'], help='The statistic to fetch')
+    parser.add_argument('--statistic', choices=stat_choices.keys(), help='The statistic to fetch')
     args = parser.parse_args()    
 
     if len(str(args.month)) == 1:
@@ -115,12 +180,30 @@ if __name__ == '__main__':
         month = args.month
 
     runner = CHIRPSController(args.name, month, args.year, args.bbox, args.statistic, args.day_of_year)
+    runner.run_models()
+
+    #if args.name == 'CHIRPS-GEFS':
+    #    date = datetime.strptime(f"{args.year}-{args.day_of_year}", "%Y-%j").strftime("%m-%d-%Y")
+    #else:
+    #    date = f"{month}/01/{args.year}"
+    
+    #df = mix.raster2df(f"results/chirps-{args.statistic}.tiff", feature_name='rainfall', band=1, date=date)
+    #df['type'] = runner.features[args.statistic]['feature_name']
+    #df.to_csv(f'results/chirps-{args.statistic}.csv', index=False)
+
+
+    '''
+    name = 'CHIRPS'
+    month = '01'
+    year = '2020'
+    bbox='[33.512234, 2.719907, 49.98171,16.501768]'
+    statistic='mm_data'
+    day_of_year = None
+    runner = CHIRPSController(name, month, year, bbox, statistic, day_of_year)
     runner.run_model()
 
-    if args.name == 'CHIRPS-GEFS':
-        date = datetime.strptime(f"{args.year}-{args.day_of_year}", "%Y-%j").strftime("%m-%d-%Y")
-    else:
-        date = f"{month}/01/{args.year}"
-    df = mix.raster2df('results/chirps.tiff', feature_name='rainfall', band=1, date=date)
-    df['type'] = runner.features[args.statistic]['feature_name']
-    df.to_csv('results/chirps.csv', index=False)
+    date = f"{month}/01/{year}"
+    df = mix.raster2df('examples/results/chirps.tiff', feature_name='rainfall', band=1, date=date)
+    df['type'] = runner.features[statistic]['feature_name']
+    df.to_csv('exmaples/results/chirps.csv', index=False)
+    '''

--- a/models/chirps/run_chirps_tiff.py
+++ b/models/chirps/run_chirps_tiff.py
@@ -22,7 +22,6 @@ import os
 if not sys.warnoptions:
     warnings.simplefilter("ignore")
 
-
 # Statistic : Output Column-Name dictionary.
 stat_choices = { 'mm_data': 'rainfall', 'mm_anomaly': 'anomaly', 'none_z-score': 'z-score'}
 
@@ -91,7 +90,11 @@ class CHIRPSController(object):
 
 
     def __init__(self, name, month, year, bbox, statistic, day_of_year=None):
-        logging.basicConfig(level=logging.INFO)        
+        logging.basicConfig(level=logging.INFO)  
+
+        if not os.path.exists('results'):
+            os.makedirs('results')
+
         self.name = name
         self.stat = statistic
         self.day_of_year = day_of_year


### PR DESCRIPTION
### Description

- Addresses #106 

### Changes
- Uses the existing `CHIRPSController` class so changes are made to `self.name`, `self.stat` etc. prior to calling `self.run_model()`.
- `run_models()` is the processing entry point to `CHIRPSController` object.
- `set_days_of_year()` is called in `__init__` and sets self.days_of_year to an array of int. For CHIRPS this will be the first day of the month; for CHIRPS-GEFS this will be the 1st and 16th. 
- `run_models` then for each day of year loops the 3 statistics, downloads and processes the tiff.


### Output

A pandas DataFrame written to `results/chirps.csv` with the columns x, y, date, rainfall, anomaly, z-score.

The following (CHIRPS-GEF example) message is displayed when the script is finished:
```
INFO:root:Processing completed. Output to results/chirps.csv. Header and tail preview:
INFO:root:           x          y        date  rainfall  anomaly   z-score
0  33.537188  16.477245  01-01-2021       0.0      0.0 -0.011031
1  33.587095  16.477245  01-01-2021       0.0      0.0 -0.019770
2  33.637003  16.477245  01-01-2021       0.0      0.0  0.000000
3  33.686910  16.477245  01-01-2021       0.0      0.0 -0.016895
4  33.736818  16.477245  01-01-2021       0.0      0.0 -0.019790
INFO:root:                x        y        date  rainfall   anomaly    z-score
185455  49.757126  2.74443  01-16-2021  5.162117  5.162117 -13.052685
185456  49.807034  2.74443  01-16-2021  5.272977  5.272977 -12.957613
185457  49.856941  2.74443  01-16-2021  4.121017  4.121017 -14.470405
185458  49.906849  2.74443  01-16-2021  4.213909  4.213909 -14.488016
185459  49.956756  2.74443  01-16-2021  4.289431  4.289431 -15.104242
```

### Examples
CHIRPS:
`python run_chirps_tiff.py --name=CHIRPS --month=01 --year=2020 --bbox='[33.512234, 2.719907, 49.98171,16.501768]' --statistic=mm_data`

CHIRPS-GEFS:
`python run_chirps_tiff.py --name=CHIRPS-GEFS --month=01 --year=2021 --bbox='[33.512234, 2.719907, 49.98171,16.501768]' --statistic=mm_data --day_of_year=306`

### Notes

- output path is essentially hard coded to "results/"; that should probably be a constant of some sort.
- `run_chirps_tiff.py` requires `mixmasta`, but that is not normally installed in `dojo`. Therefore, testing was performed  by copying the script to a mixmasta docker container.
