### PR TITLE
Fixed config query

### DIFF
--- a/api/src/dojo.py
+++ b/api/src/dojo.py
@@ -27,22 +27,36 @@ def search_by_model(model_id):
 
 def search_for_config(model_id, path):
     q = {
-        "query": {
-            "bool": {
-                "must": [
+        "query":{
+            "bool":{
+                "filter":[
                     {
-                        "match": {
-                            "model_id": {
-                                "query": model_id,
+                    "bool":{
+                        "filter":[
+                            {
+                                "bool":{
+                                "should":[
+                                    {
+                                        "match_phrase":{
+                                            "path": path
+                                        }
+                                    }
+                                ],
+                                }
                             },
-                        },
-                    },
-                    {
-                        "match": {
-                            "path": {
-                                "query": path,
-                            },
-                        },
+                            {
+                                "bool":{
+                                "should":[
+                                    {
+                                        "match_phrase":{
+                                            "model_id": model_id
+                                        }
+                                    }
+                                ],
+                                }
+                            }
+                        ]
+                    }
                     }
                 ]
             }


### PR DESCRIPTION
Addresses #124 

To test this PR you should try to create a model with 2 configs. 

To test just the query, you can run ES locally and push a couple configs _with different `paths`_ but the same `model_id` to the `configs` index:

```
from elasticsearch import Elasticsearch
es = Elasticsearch('http://localhost:9200')

body = {
    "model_id": "1a57d34c-8ebf-4784-93e1-526380e8633c",
    "s3_url": "https://jataware-world-modelers.s3.amazonaws.com/dojo/shorthand_templates/64e8336b-4d5f-4971-bb16-74a7fd3b566f/home/clouseau/dummy-model/configFiles/parameters.json.template.txt",
    "s3_url_raw": "https://jataware-world-modelers.s3.amazonaws.com/dojo/shorthand_templates/64e8336b-4d5f-4971-bb16-74a7fd3b566f/home/clouseau/dummy-model/configFiles/parameters.json.raw.txt",
    "path": "/home/clouseau/dummy-model/configFiles/test.json",
    "md5_hash": "c982ef4fdc0ebb2fb43a9b86d23d0b7d",
    "id": "567890123123"
  }

# index first config
es.index('configs', body, id=body['id'])

# adjust config path and id
body['path'] = '/home/clouseau/dummy-model/configFiles/test_2.json'
body['id'] = 'asdfasdf'

# index 2nd config
es.index('configs', body, id=body['id'])

path = body['path']
model_id = body['model_id']

q = {
   "query":{
      "bool":{
         "filter":[
            {
               "bool":{
                  "filter":[
                     {
                        "bool":{
                           "should":[
                              {
                                 "match_phrase":{
                                    "path": path
                                 }
                              }
                           ],
                        }
                     },
                     {
                        "bool":{
                           "should":[
                              {
                                 "match_phrase":{
                                    "model_id": model_id
                                 }
                              }
                           ],
                        }
                     }
                  ]
               }
            }
         ]
      }
   }
}

configs = es.search(index='configs', size=500, body=query)['hits']['hits']
print(len(configs))
```

