### PR TITLE
Removed status code check on accessory files

### DIFF
--- a/api/src/runs.py
+++ b/api/src/runs.py
@@ -174,8 +174,7 @@ def create_run(run: RunSchema.ModelRunSchema):
 
     ### Handle accessory files.
     accessoryFiles = get_accessory_files(run.model_id) # call dojo.py API method directly.
-    if accessoryFiles.status_code == 404:
-        accessoryFiles = []
+    
     logger.info(accessoryFiles)
     accessory_dirs = {}
     for accessoryFile in accessoryFiles:


### PR DESCRIPTION
This PR removes a line that is causing all model runs to fail with:

```
  File "./src/runs.py", line 177, in create_run
    if accessoryFiles.status_code == 404:
AttributeError: 'list' object has no attribute 'status_code'
```

This is because the [ES query to obtain the accessories](https://github.com/jataware/dojo/blob/master/api/src/dojo.py#L368) always returns a list even if there are no search results.

The exception to this would be if Dojo cannot connect to ES or the query fails. In that case we may want to bubble something up that makes clear what is happening. Do we want to run the model without accessories (or outputs/configs/etc)? Or do we want to return some error clarifying what is happening on create `/runs`? I think we probably want to error out the run but provide some clue as to why it failed.

@mattprintz I'm going to merge and deploy this to make sure model runs will work for the time being but we should look at [the ES exception handling](https://github.com/jataware/dojo/blob/master/api/src/dojo.py#L370-L374) since I think it shouldn't be 404 but something else since that failure will (I think...) only occur upon connectivity problems with ES.