### PR TITLE
Model testing capability

### DIFF
--- a/api/src/models.py
+++ b/api/src/models.py
@@ -338,7 +338,7 @@ def publish_model(model_id: str, publish_data: ModelSchema.PublishSchema):
         content="Model published",
     )
 
-@router.post("/models/{model_id}/test")
+@router.get("/models/{model_id}/test")
 def test_model(model_id: str):
     """
     This endpoint tests a model's functionality within Dojo.
@@ -346,5 +346,5 @@ def test_model(model_id: str):
     run_id = run_model_with_defaults(model_id)
     return Response(
         status_code=status.HTTP_200_OK,
-        content=f"Model test run submitted with run id {run_id}",
+        content=run_id,
     ) 

--- a/api/src/models.py
+++ b/api/src/models.py
@@ -20,6 +20,7 @@ from src.settings import settings
 from src.dojo import search_and_scroll, copy_configs, copy_outputfiles, copy_directive, copy_accessory_files
 from src.ontologies import get_ontologies
 from src.causemos import notify_causemos, submit_run
+from src.utils import run_model_with_defaults
 
 router = APIRouter()
 
@@ -336,3 +337,14 @@ def publish_model(model_id: str, publish_data: ModelSchema.PublishSchema):
         status_code=status.HTTP_200_OK,
         content="Model published",
     )
+
+@router.post("/models/{model_id}/test")
+def test_model(model_id: str):
+    """
+    This endpoint tests a model's functionality within Dojo.
+    """
+    run_id = run_model_with_defaults(model_id)
+    return Response(
+        status_code=status.HTTP_200_OK,
+        content=f"Model test run submitted with run id {run_id}",
+    ) 

--- a/api/src/runs.py
+++ b/api/src/runs.py
@@ -337,3 +337,18 @@ def update_run(payload: RunSchema.ModelRunSchema):
         headers={"location": f"/api/runs/{run_id}"},
         content=f"Updated run with id = {run_id}",
     )
+
+@router.get("/runs/{run_id}/test")
+def test_run_status(run_id: str) -> RunSchema.RunStatusSchema:
+    run = get_run(run_id)
+    status = run.get("attributes",{}).get("status",None)
+    model_id = run.get("model_id")
+    body = {"run_id": run_id,
+            "status": status, 
+            "model_name": run.get("model_name"), 
+            "executed_at": run.get("attributes",{}).get("executed_at",None)}
+    if status:
+        es.index(index="tests", body=body, id=model_id)
+        return status
+    else:
+        return "running" 

--- a/api/src/utils.py
+++ b/api/src/utils.py
@@ -1,4 +1,9 @@
 from validation import ModelSchema
+import time
+from elasticsearch import Elasticsearch
+
+from src.settings import settings
+es = Elasticsearch([settings.ELASTICSEARCH_URL], port=settings.ELASTICSEARCH_PORT)
 
 def try_parse_int(s: str, default: int = 0) -> int:
     try:
@@ -34,3 +39,40 @@ def delete_matching_records_from_model(model_id, record_key, record_test):
     modify_model(model_id, ModelSchema.ModelMetadataPatchSchema(**update))
 
     return record_count
+
+def run_model_with_defaults(model_id):
+    """
+    This function takes in a model and submits a default run to test that model's functionality
+    """
+
+    from src.models import get_model 
+    from src.runs import create_run, current_milli_time
+    from validation.RunSchema import ModelRunSchema
+
+    model = get_model(model_id)
+
+    params = []
+    for param in model.get("parameters",[]):
+        param_obj = {}
+        param_obj['name'] = param['name']
+        param_obj['value'] = param['default']
+        params.append(param_obj)
+
+    run_id = f"{model['name']}-{current_milli_time()}"
+
+    run = ModelRunSchema(id=run_id,
+                         model_id=model_id,
+                         model_name=model["name"],
+                         parameters=params,
+                         data_paths=[],
+                         tags=[],
+                         is_default_run=True,
+                         created_at = current_milli_time())
+
+    create_run(run)
+
+    # Store model ID to `tests` index with `status` set to `running`
+    body = {"status": "running", "created_at": run.created_at, "run_id": run.id}
+    es.index(index="tests", body=body, id=model_id)
+
+    return run_id    

--- a/api/validation/RunSchema.py
+++ b/api/validation/RunSchema.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from typing import List, Optional, Union
-
+from enum import Enum
 from pydantic import BaseModel, Extra, Field
 from pydantic.utils import Obj
 
@@ -96,3 +96,8 @@ class RunLogsSchema(BaseModel):
         description="tasks",
         title="tasks",
     )
+
+class RunStatusSchema(Enum):
+    success = "success"
+    running = "running"
+    failed = "failed"     

--- a/test-models.py
+++ b/test-models.py
@@ -1,3 +1,26 @@
+"""
+TEST MODELS CLI TOOL
+
+This CLI provides two commands for testing models via the Dojo API.
+
+The first command is the "test" command. This command will submit all published models to the Dojo API for testing.
+
+The second command is the "validate" command. It checks the status of each test run via the Dojo API, ensuring that the latest test status
+is stored to Elasticsearch's `tests` index.
+
+Usage:
+
+```
+python3 test-models.py --dojo_url="dojo-test.com" --dojo_user="user" --dojo_pwd="pwd" test
+python3 test-models.py --dojo_url="dojo-test.com" --dojo_user="user" --dojo_pwd="pwd" validate
+```
+
+If running on the same machine as the Dojo API, you can drop the options and just run:
+
+```
+python3 test-models.py test
+```
+"""
 import requests
 import click
 import time

--- a/test-models.py
+++ b/test-models.py
@@ -1,0 +1,43 @@
+import requests
+import click
+import time
+
+@click.group()
+@click.option('--dojo_url', default='localhost:8000', help='The Dojo URL')
+@click.option('--dojo_user', default='', help='The Dojo username.')
+@click.option('--dojo_pwd', default='', help='The Dojo password.')
+@click.pass_context
+def cli(ctx, dojo_url, dojo_user, dojo_pwd):
+    ctx.ensure_object(dict)
+    if dojo_user == '':
+        ctx.obj['dojo_auth_url'] = f"http://{dojo_url}"
+    else:
+        ctx.obj['dojo_auth_url'] = f"https://{dojo_user}:{dojo_pwd}@{dojo_url}"
+
+@cli.command(name='test')
+@click.pass_context
+def test(ctx):
+    """Obtain list of published models and submit them to Dojo for testing."""
+    dojo_auth_url = ctx.obj['dojo_auth_url']
+    models = requests.get(f"{dojo_auth_url}/models/latest?size=100").json()
+    for model in models.get('results', []):
+        if model.get("is_published",False):
+            click.echo(f"Submitting model {model['id']} to Dojo for testing.")
+            response = requests.get(f"{dojo_auth_url}/models/{model['id']}/test")
+            with open("test_models.log", "a") as f:
+                f.write(f"{time.strftime('%Y-%m-%d %H:%M:%S')}\t{model['id']}\t{response.text}\n")
+
+@cli.command(name='validate')
+@click.pass_context
+def validate(ctx):
+    """Validate submitted tests for success/failure."""
+    dojo_auth_url = ctx.obj['dojo_auth_url']
+    with open('test_models.log', 'r') as f:
+        for line in f:
+            time, model_id, run_id = line.replace('\n','').split('\t')
+            click.echo(f"Submitting run_id {run_id} to Dojo for validation.")
+            response = requests.get(f"{dojo_auth_url}/runs/{run_id}/test")
+            click.echo(response.text)
+
+if __name__ == '__main__':
+    cli(obj={})


### PR DESCRIPTION
This PR:

1. Adds `/models/{model_id}/test` which submits the default run for a given model for execution. Returns a `run_id`
2. Adds `/runs/{run_id}/test` which checks the status for a test run. If completed, it stores the `status` to the `tests` index in Elasticsearch. `status` is one of `success` or `failed`

The `tests` index schema looks like:

```
{
   "run_id":"test-run-123",
   "status":"success",
   "model_name":"test-model",
   "executed_at":"2022-02-04 02:10:02"
}
```

> Note: the `id` in the `tests` index is the `model_id` so **only 1 document can exist per model**

These endpoints can be leveraged by invoking the `test-models.py` CLI script. This script has 2 commands:

1. `test` which submits all `published` models to Dojo for testing
2. `validate` which checks each submitted run for its status via the Dojo `/runs/{run_id}/test` endpoint.