### PR TITLE
Replaces image lookup with tag lookup query

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -15,6 +15,6 @@ CAUSEMOS_DEBUG=true
 CAUSEMOS_USER=worldmodelers
 CAUSEMOS_PWD=world!
 CAUSEMOS_IND_URL=https://causemos.uncharted.software/api/maas
-DOCKERHUB_URL=https://hub.docker.com/v2
+DOCKERHUB_URL=https://registry.hub.docker.com/v2
 DOCKERHUB_USER=username_here
 DOCKERHUB_PWD=pwd_here

--- a/api/src/dockerhub.py
+++ b/api/src/dockerhub.py
@@ -92,15 +92,15 @@ def get_image_tags(repo):
     """
 
     url = (
-        f"{settings.DOCKERHUB_URL}/namespaces/"
-        f"{settings.DOCKERHUB_ORG}/repositories/"
-        f"{repo}/images?ordering=last_activity&page_size=100&currently_tagged=true"
+        f"{settings.DOCKERHUB_URL}/"
+        f"repositories/{settings.DOCKERHUB_ORG}/"
+        f"{repo}/tags?page_size=100"
     )
 
     headers = {"Accept": "application/json", "Authorization": f"Bearer {auth_token}"}
 
     # Get list of image tag dicts.
-    image_tags = get_repo_image_details(url, headers, [])
+    image_tags = get_repo_image_details(url, headers, [], repo)
 
     model_images = [
         image_tag.get("display_name")
@@ -143,7 +143,7 @@ def get_image_tags(repo):
     return curated_tags
 
 
-def get_repo_image_details(url: str, headers: dict, image_tags) -> list:
+def get_repo_image_details(url: str, headers: dict, image_tags, repo: str) -> list:
     """
     Description
     -----------
@@ -177,46 +177,57 @@ def get_repo_image_details(url: str, headers: dict, image_tags) -> list:
         ----------------
             {
             "count": 79,
-            "next": "https://hub.docker.com/v2/namespaces/jataware/repositories/dojo-publish/images?page=2&status=active",
+            "next": "https://hub.docker.com/v2/jataware/dojo-publish/tags?page=2",
             "previous": null,
             "results": [
                 {
-                    "namespace": "jataware",
-                    "repository": "dojo-publish",
-                    "digest": "sha256:81ae08c9a8093e0c0c10313b844aa70e1f5be6c582b1c1a41fc073a37df35528",
-                    "tags": [
+                    'creator': 13929046, 
+                    'id': 200325956, 
+                    'image_id': None, 
+                    'images': [
                         {
-                            "tag": "GoogleTrends-latest",
-                            "is_current": true
+                            'architecture': 'amd64', 
+                            'features': '', 
+                            'variant': None, 
+                            'digest': 'sha256:b991dcdf746cfd92471dcd3dcacc78d1d1e6a9e3397c26da9d5b552ad6ba11ff', 
+                            'os': 'linux', 
+                            'os_features': '', 
+                            'os_version': None, 
+                            'size': 8769398376, 
+                            'status': 'active', 
+                            'last_pulled': None, 
+                            'last_pushed': '2022-03-30T14:17:02.184254Z'
                         }
-                    ],
-                    "last_pushed": "2021-07-15T01:16:32.454626Z",
-                    "last_pulled": "2021-07-21T14:58:42.765245Z",
-                    "status": "active"
+                    ], 
+                    'last_updated': '2022-03-30T14:17:02.313327Z', 
+                    'last_updater': 13929046, 
+                    'last_updater_username': 'automationjat', 
+                    'name': '0259da01-e085-4dfc-b432-17c23c14d569', 
+                    'repository': 14874028, 
+                    'full_size': 8769398376, 
+                    'v2': True, 
+                    'tag_status': 'active', 
+                    'tag_last_pulled': None, 
+                    'tag_last_pushed': '2022-03-30T14:17:02.313327Z'
                 },
             ...
         """
         if "results" in resp:
             for result in resp["results"]:
-                if "tags" in result:
-                    tags = result["tags"][0]
-                    tag = tags["tag"]
-                    image = result["namespace"] + "/" + result["repository"] + ":" + tag
-                    display_name = tag.replace("-latest", "")
-                    updated_at = result["last_pushed"]
-
-                    image_tags.append(
-                        {
-                            "display_name": display_name,
-                            "image": image,
-                            "sort_order": 0,
-                            "updated_at": updated_at,
-                        }
-                    )
+                updated_at = result["tag_last_pushed"]
+                tag = result['name']
+                image = f"{settings.DOCKERHUB_ORG}/{repo}-publish:{tag}"
+                display_name=tag.replace("-latest", "")
+                image_tags.append({
+                    "display_name": display_name,
+                    "image": image,
+                    "sort_order": 0,
+                    "updated_at": updated_at,
+                })
 
         # Get the next page if there is a "next".
         if "next" in resp and resp["next"] is not None:
-            image_tags = get_repo_image_details(resp["next"], headers, image_tags)
+            image_tags = get_repo_image_details(resp["next"], headers, image_tags, repo)
 
         return image_tags
 


### PR DESCRIPTION
Works around issue with 403 returned on previous `https://hub.docker.com/v2/namespaces/` by instead accessing `https://registry.hub.docker.com/v2/{org}/{image}/tags`