### PR TITLE
Deprecate datasets/indicators

### DIFF
--- a/api/src/causemos.py
+++ b/api/src/causemos.py
@@ -3,6 +3,35 @@ import json
 import os
 from fastapi.logger import logger
 
+def deprecate_dataset(dataset_id):
+    """
+    A function to deprecate a dataset within Causemos
+
+    PUT https://causemos.uncharted.software/api/maas/datacubes/exampleID/deprecate
+
+    """
+    url = f'{os.getenv("CAUSEMOS_IND_URL")}/datacubes/{dataset_id}/deprecate'
+    causemos_user = os.getenv("CAUSEMOS_USER")
+    causemos_pwd = os.getenv("CAUSEMOS_PWD")
+
+    try:
+        # Notify Uncharted
+        if os.getenv("CAUSEMOS_DEBUG") == "true":
+            logger.info("CauseMos debug mode: no need to notify Uncharted")
+            return
+        else:
+            logger.info(f"Notifying CauseMos of {type} creation...")
+            response = requests.put(
+                url,
+                auth=(causemos_user, causemos_pwd),
+            )
+            logger.info(f"Response from Uncharted: {response.text}")
+            return
+
+    except Exception as e:
+        logger.error(f"Encountered problems communicating with Causemos: {e}")
+        logger.exception(e)
+
 
 def notify_causemos(data, type="indicator"):
     """

--- a/api/src/causemos.py
+++ b/api/src/causemos.py
@@ -20,7 +20,7 @@ def deprecate_dataset(dataset_id):
             logger.info("CauseMos debug mode: no need to notify Uncharted")
             return
         else:
-            logger.info(f"Notifying CauseMos of {type} creation...")
+            logger.info(f"Notifying Causemos to deprecate dataset")
             response = requests.put(
                 url,
                 auth=(causemos_user, causemos_pwd),

--- a/api/src/indicators.py
+++ b/api/src/indicators.py
@@ -20,6 +20,7 @@ from src.settings import settings
 from src.dojo import search_and_scroll
 from src.ontologies import get_ontologies
 from src.causemos import notify_causemos
+from src.causemos import deprecate_dataset
 
 import os
 
@@ -76,6 +77,7 @@ def get_latest_indicators(size=10000):
             "name",
             "id",
             "created_at",
+            "deprecated",
             "maintainer.name",
             "maintainer.email",
         ],
@@ -149,6 +151,9 @@ def deprecate_indicator(indicator_id: str):
         indicator = es.get(index="indicators", id=indicator_id)["_source"]
         indicator["deprecated"] = True
         es.index(index="indicators", id=indicator_id, body=indicator)
+
+        # Tell Causemos to deprecate the dataset on their end
+        deprecate_dataset(indicator_id)
     except:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     return Response(


### PR DESCRIPTION
This PR adds a deprecate_dataset function to causemos.py that hits Causemos to deprecate a dataset on their end. This gets called when we deprecate an indicator in indicators.py. 

It also adds the `deprecated` flag to the values returned with the datasets (the new name on the front end for indicators) from the `get_latest_indicators` function. 