### PR TITLE
Backend changes to support Browse Runs Phantom UI functionality

### DIFF
--- a/api/src/runs.py
+++ b/api/src/runs.py
@@ -71,8 +71,10 @@ def search_runs(request: Request, model_name: str = Query(None), model_id: str =
     else:  # no model name specified
         q = {"query": {"match_all": {}}}
 
+    sort = ["created_at:desc"]
+
     if not scroll_id:
-        results = es.search(index='runs', body=q, scroll="2m", size=size)
+        results = es.search(index='runs', body=q, sort=sort, scroll="2m", size=size)
     else:
         results = es.scroll(scroll_id=scroll_id, scroll="2m")
 

--- a/api/src/runs.py
+++ b/api/src/runs.py
@@ -268,6 +268,8 @@ def create_run(run: RunSchema.ModelRunSchema):
     logging.info(f"Response from DMC: {json.dumps(response.json(), indent=4)}")
 
     run.created_at = current_milli_time()
+    run.attributes["status"] = "Running"
+
     es.index(index="runs", body=run.dict(), id=run.id)
     return Response(
         status_code=status.HTTP_201_CREATED,

--- a/api/src/runs.py
+++ b/api/src/runs.py
@@ -73,6 +73,15 @@ def search_runs(request: Request, model_name: str = Query(None), model_id: str =
 
     sort = ["created_at:desc"]
 
+    count = es.count(index='runs', body=q)
+
+    if count["count"] == 0:
+        return {
+            "hits": 0,
+            "scroll_id": None,
+            "results": []
+        }
+
     if not scroll_id:
         results = es.search(index='runs', body=q, sort=sort, scroll="2m", size=size)
     else:
@@ -91,8 +100,6 @@ def search_runs(request: Request, model_name: str = Query(None), model_id: str =
         scroll_id = results.get("_scroll_id", None)
 
     results = [i["_source"] for i in results["hits"]["hits"]]
-
-    count = es.count(index='runs', body=q)
 
     if not param_filters:
         return {

--- a/api/src/utils.py
+++ b/api/src/utils.py
@@ -68,6 +68,7 @@ def run_model_with_defaults(model_id):
                          data_paths=[],
                          tags=[],
                          is_default_run=True,
+                         attributes={},
                          created_at = current_milli_time())
 
     create_run(run)

--- a/api/validation/DojoSchema.py
+++ b/api/validation/DojoSchema.py
@@ -5,8 +5,7 @@
 
 from typing import Dict, List, Optional
 from pydantic import BaseModel, Field
-from validation import ModelSchema, IndicatorSchema
-
+from validation import RunSchema, ModelSchema, IndicatorSchema
 
 
 class IndicatorSearchResult(BaseModel):
@@ -144,6 +143,15 @@ class ModelSearchResult(BaseModel):
         description="Provide this scroll ID to receive the next page of results",
     )
 
+class RunSearchResult(BaseModel):
+    hits: int = Field(title="Total hits for query", example="113")
+    results: List[RunSchema.ModelRunSchema] = Field(
+        title="Results", description="Array of result objects"
+    )
+    scroll_id: Optional[str] = Field(
+        title="Scroll ID",
+        description="Provide this scroll ID to receive the next page of results",
+    )
 
 class ParameterFormatter(BaseModel):
     """


### PR DESCRIPTION
Change Queued status to Running when a model run starts - #198

Sets status=running when a model run starts. Tested manually in frontend; that is:
- Started a run before updating- saw job status reflected as Queued.
- Made change from this PR. Started a second run.
- Noted that frontend now displayed Running upon starting the Job.

Additionally, modified search_runs "index" endpoint to add pagination and page size, in order to support returning all previous runs from UI.

Tested manually only.

How are we testing API changes? Do we have unit/integration tests? Maybe some rest script/playbook files? Manual testing only?